### PR TITLE
Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ TM_UPTIME  =
 .PHONY: osx
 
 osx:
-	@make CLI=1 TM_FS=posix TM_NET=posix TM_UPTIME=posix OPTIM=$(OPTIM) all
+	@+make CLI=1 TM_FS=posix TM_NET=posix TM_UPTIME=posix OPTIM=$(OPTIM) all
 
 embed:
-	@make ARM=1 TM_FS=fat OPTIM=$(OPTIM) all
+	@+make ARM=1 TM_FS=fat OPTIM=$(OPTIM) all
 
 
 


### PR DESCRIPTION
- Compile `embed` with gcc-arm-embedded (also still compiles with CodeSourcery)
- Give makefile rules proper dependencies so `make` is a no-op when nothing has changed and file changes propagate correctly (Rule of thumb: If a makefile rule has commands in the body and does not specify a source and a target that are both filenames, it's probably wrong)
- Add `-lbsd` to build `strlcpy` to build on linux (See http://lwn.net/Articles/507319/ for that mess)
- Renames `build/osx` to `build/pc` because it's not always OSX
