### PR TITLE
Clean up event loop refcount on exit.

### DIFF
--- a/src/tm_event.c
+++ b/src/tm_event.c
@@ -73,6 +73,7 @@ int event_loop_retval = 0;
 
 int tm_runtime_run(const char* script, const char** argv, int argc)
 {
+	tm_event_count = 0;
 	event_loop_running = true;
 	event_loop_keep_running = true;
 	volatile bool have_called_exit = false;

--- a/src/tm_timer.c
+++ b/src/tm_timer.c
@@ -180,4 +180,5 @@ void tm_timer_cleanup() {
 		timers_head = t->next;
 		destroy_timer(t);
 	}
+	tm_event_unref(&tm_timer_event);
 }


### PR DESCRIPTION
Fixes an issue that prevents the script from exiting when all event
handlers are ended.

Test case: Run a script that does a setInterval. Ctrl-C it. Run another
script that should end on its own. Check that the event loop exits when
the script ends.

<!--travisplexer-->

---

<table><tr><td><b>ARM Cortex-M</b></td><td>
<a href="https://magnum.travis-ci.com/tessel/runtime"><img alt="Build Status" src="https://magnum.travis-ci.com/tessel/runtime.svg?token=QsFQ9CsYegvj7x78qiit&branch=travis-pr-43-arm"></a>
</td></tr><tr><td><b>OS X</b></td><td>
<a href="https://magnum.travis-ci.com/tessel/runtime"><img alt="Build Status" src="https://magnum.travis-ci.com/tessel/runtime.svg?token=QsFQ9CsYegvj7x78qiit&branch=travis-pr-43-osx"></a>
</td></tr></table>
