### PR TITLE
Getting the basic HTTP server example to respond to requests.

### DIFF
--- a/src/colony/modules/http.js
+++ b/src/colony/modules/http.js
@@ -24,6 +24,7 @@ var Writable = require('stream').Writable;
  */
 
 function ServerResponse (req, connection) {
+  Writable.call(this);
   this.req = req;
   this.connection = connection;
   this.headers = {};
@@ -120,6 +121,7 @@ ServerResponse.prototype.end = function (data) {
  */
 
 function ServerRequest (connection) {
+  Readable.call(this);
   var self = this;
 
   this.headers = {};


### PR DESCRIPTION
The simple HTTP server example, found in `test/todo/http-server.js`, currently throws an error when responding to requests.

I added super constructor calls to the http module's ServerResponse and ServerRequest constructor functions.  These constructors inherit stream.Writable and stream.Readable, respectively.

With this fix, the basic HTTP server does run on my MacBook Pro.  I just ordered a Tessel last night, so I haven't tried it on the hardware.
