### PR TITLE
Adds support for Number.isFinite

### DIFF
--- a/src/colony/lua/colony-js.lua
+++ b/src/colony/lua/colony-js.lua
@@ -570,8 +570,12 @@ end
 global.Number.prototype = num_proto
 num_proto.constructor = global.Number
 
-global.Number.isFinite = function(this, obj)
-  return arg ~= math.huge and arg ~= -math.huge and global.isNaN(this, arg)
+global.Number.isFinite = function(this, arg)
+  if type(arg) == 'number' then
+    return arg ~= math.huge and arg ~= -math.huge and not global.isNaN(this, arg)
+  else
+    return false
+  end
 end
 
 -- Object

--- a/test/issues/issue-runtime-158.js
+++ b/test/issues/issue-runtime-158.js
@@ -1,0 +1,8 @@
+console.log('1..7');
+console.log(Number.isFinite('5') == false ? 'ok' : 'not ok');
+console.log(Number.isFinite(NaN) == false ? 'ok' : 'not ok');
+console.log(Number.isFinite(Infinity) == false ? 'ok' : 'not ok');
+console.log(Number.isFinite(-Infinity) == false ? 'ok' : 'not ok');
+console.log(Number.isFinite(1.7976931348623157E+10308) == false ? 'ok' : 'not ok');
+console.log(Number.isFinite(1.7976931348623157E+10308 - 1) == true ? 'ok' : 'not ok');
+console.log(Number.isFinite(5) == true ? 'ok' : 'not ok');


### PR DESCRIPTION
Turns out my original code for `isFinite` is what we needed for [`Number.isFinite`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite).  
