### PR TITLE
Return NaN if parseFloat not parseable

### DIFF
--- a/src/colony/lua/colony-js.lua
+++ b/src/colony/lua/colony-js.lua
@@ -1145,7 +1145,7 @@ global.isNaN = function (this, arg)
 end
 
 global.parseFloat = function (ths, str)
-  return tonumber(tostring(str), 10) or 0
+  return tonumber(tostring(str), 10) or (0/0)
 end
 
 global.parseInt = function (ths, str, radix)

--- a/test/suite/number.js
+++ b/test/suite/number.js
@@ -16,5 +16,7 @@ console.log(Number.isSafeInteger((9007199254740991)) == true ? 'ok' : 'not ok - 
 console.log(Number.isSafeInteger(3) == true ? 'ok' : 'not ok - isSafeInteger 3');
 
 console.log(Number.parseInt('4') == 4 ? 'ok' : 'not ok - parseInt int string');
+console.log(isNaN(Number.parseInt('string')) ? 'ok' : 'not ok - parseInt string');
 
 console.log(Number.parseFloat('4.3') == 4.3 ? 'ok' : 'not ok - parseFloat float string');
+console.log(isNaN(Number.parseFloat('string')) ? 'ok' : 'not ok - parseFloat string' );


### PR DESCRIPTION
It was returning 0 before.

Reveals bigger issue of how colony represents javascript's NaN as Lua's 'nan'. Functionally equivalent but possibly confusing for node users.
