### PR TITLE
Make require('os').platform()/arch() returns the same as process.platform/arch

### DIFF
--- a/src/colony/lua/colony-node.lua
+++ b/src/colony/lua/colony-node.lua
@@ -687,7 +687,7 @@ global.process.memoryUsage = function (ths)
   });
 end
 global.process.platform = "tessel"
-global.process.arch = "arm"
+global.process.arch = "armv7-m"
 global.process.versions = js_obj({
   node = "0.10.0",
   colony = "0.10.0"

--- a/src/colony/modules/os.js
+++ b/src/colony/modules/os.js
@@ -30,7 +30,7 @@ exports.platform = function () {
 }
 
 exports.arch = function () {
-	return 'arm'
+	return 'armv7-m'
 }
 
 exports.release = function () {


### PR DESCRIPTION
Fixes #263
