### PR TITLE
Add missing object arg, opt thisArg to Array methods. Fixes gh-283

### DIFF
--- a/src/colony/colony_init.c
+++ b/src/colony/colony_init.c
@@ -191,7 +191,11 @@ static int arr_proto_forEach (lua_State* L)
 
 		// i
 		lua_pushnumber(L, i);
-		lua_call(L, 3, 0);
+
+		// third "object" argument to callbackfn
+		lua_pushvalue(L, 1);
+
+		lua_call(L, 4, 0);
 	}
 
 	lua_settop(L, 1);

--- a/src/colony/lua/colony-js.lua
+++ b/src/colony/lua/colony-js.lua
@@ -499,18 +499,38 @@ arr_proto.indexOf = function (this, val)
   return -1
 end
 
-arr_proto.map = function (ths, fn)
+arr_proto.map = function (this, fn, ...)
   local a = js_arr({}, 0)
-  for i=0,ths.length-1 do
-    a:push(fn(ths, ths[i], i))
+  local args = table.pack(...)
+  -- t _should_ be set to undefined, per spec.
+  -- Since there is no notion of strict mode,
+  -- setting to global has the same observable semantics.
+  local t = global
+
+  if args.length > 0 then
+    t = args[1]
+  end
+
+  for i=0,this.length-1 do
+    a:push(fn(t, this[i], i, this))
   end
   return a
 end
 
-arr_proto.filter = function (this, fn)
+arr_proto.filter = function (this, fn, ...)
   local a = js_arr({}, 0)
+  local args = table.pack(...)
+  -- t _should_ be set to undefined, per spec.
+  -- Since there is no notion of strict mode,
+  -- setting to global has the same observable semantics.
+  local t = global
+
+  if args.length > 0 then
+    t = args[1]
+  end
+
   for i=0,this.length-1 do
-    if fn(this, this[i], i) then
+    if fn(t, this[i], i, this) then
       a:push(this[i])
     end
   end
@@ -554,23 +574,23 @@ end
 
 arr_proto.forEach = arr_proto_forEach
 
-arr_proto.some = function (ths, fn)
-  for i=0,ths.length-1 do
-    if fn(ths, ths[i], i) then
+arr_proto.some = function (this, fn, ...)
+  local args = table.pack(...)
+  -- t _should_ be set to undefined, per spec.
+  -- Since there is no notion of strict mode,
+  -- setting to global has the same observable semantics.
+  local t = global
+
+  if args.length > 0 then
+    t = args[1]
+  end
+
+  for i=0,this.length-1 do
+    if fn(t, this[i], i, this) then
       return true
     end
   end
   return false
-end
-
-arr_proto.filter = function (ths, fn)
-  local a = js_arr({}, 0)
-  for i=0,ths.length-1 do
-    if global._truthy(fn(ths, ths[i], i)) then
-      a:push(ths[i])
-    end
-  end
-  return a
 end
 
 --[[

--- a/test/issues/issue-runtime-283.js
+++ b/test/issues/issue-runtime-283.js
@@ -1,0 +1,128 @@
+var a = [1];
+var o = {};
+var g = global || this;
+var result = 0;
+
+/**
+ *
+ * callbackfn parameters:
+ *
+ * 1. Value
+ * 2. Index
+ * 3. The Object
+ *
+ * + optional thisArg
+ *
+ * `this` will be whatever the global object is,
+ * unless explicitly specified.
+ *
+ */
+
+a.forEach(function(value, index, object) {
+  if (value === 1) {
+    result++;
+  }
+
+  if (index === 0) {
+    result++;
+  }
+
+  if (object === a) {
+    result++;
+  }
+
+  if (this === o) {
+    result++;
+  }
+}, o);
+
+a.forEach(function(value, index, object) {
+  if (this === g) {
+    result++;
+  }
+});
+
+var mapped = a.map(function(value, index, object) {
+  if (value === 1) {
+    result++;
+  }
+
+  if (index === 0) {
+    result++;
+  }
+
+  if (object === a) {
+    result++;
+  }
+
+  if (this === o) {
+    result++;
+  }
+
+  return value;
+}, o);
+
+a.map(function(value, index, object) {
+  if (this === g) {
+    result++;
+  }
+});
+
+a.some(function(value, index, object) {
+  if (value === 1) {
+    result++;
+  }
+
+  if (index === 0) {
+    result++;
+  }
+
+  if (object === a) {
+    result++;
+  }
+
+  if (this === o) {
+    result++;
+  }
+}, o);
+
+a.some(function(value, index, object) {
+  if (this === g) {
+    result++;
+  }
+});
+
+
+var filtered = a.filter(function(value, index, object) {
+  if (value === 1) {
+    result++;
+  }
+
+  if (index === 0) {
+    result++;
+  }
+
+  if (object === a) {
+    result++;
+  }
+
+  if (this === o) {
+    result++;
+  }
+
+  return true;
+}, o);
+
+a.filter(function(value, index, object) {
+  if (this === g) {
+    result++;
+  }
+});
+
+console.log('1..3');
+// This will pass when forEach thisArg is implemented
+// and default this is corrected. The value of `result`
+// is currently 18.
+console.log(result === 20 ? 'ok' : 'not ok');
+console.log(mapped[0] === 1 ? 'ok' : 'not ok');
+console.log(filtered[0] === 1 ? 'ok' : 'not ok');


### PR DESCRIPTION
- `forEach` thisArg to be implemented in follow up commit
- Followed general convention of using var args for optional `thisArg`
- Remove duplicate `filter` definition

Signed-off-by: Rick Waldron waldron.rick@gmail.com
