### PR TITLE
Adds colony-compiler link to runtime rather than separate install.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "bin": {
     "colony": "./out/Release/colony",
+    "colony-compiler": "./node_modules/colony-compiler/bin/colony-compiler.js",
     "colony-profile": "./bin/colony-profile.js"
   },
   "directories": {


### PR DESCRIPTION
This prevents runtime from getting out of sync with colony-compiler, in the case that you are testing out PC versions.
