### PR TITLE
Prevents _G object leaking userdata into JS. Fixes #305.

### DIFF
--- a/src/colony/lua/colony-js.lua
+++ b/src/colony/lua/colony-js.lua
@@ -69,7 +69,20 @@ global._in = js_in
 global._break = js_break
 global._cont = js_cont
 global._with = js_with
-global._G = _G
+global._G = {}
+
+-- Hack for exposed _G object until it can be removed.
+setmetatable(global._G, {
+  __index = function (this, key)
+    if type(_G[key]) ~= 'userdata' then
+      return _G[key]
+    end
+    return nil
+  end,
+  __newindex = function (this, key, value)
+    _G[key] = value
+  end
+})
 
 -- in-code modules
 

--- a/test/issues/issue-runtime-305.js
+++ b/test/issues/issue-runtime-305.js
@@ -1,0 +1,5 @@
+var tap = require('../tap')
+
+tap(1)
+
+tap.eq(global._G && global._G._HSMATCH, null, '_HSMATCH object should not be accessible');


### PR DESCRIPTION
This should be corrected in https://github.com/tessel/runtime/issues/374 by removing _G from global object entirely.
