### PR TITLE
implement `._read` for ServerRequest

### DIFF
--- a/src/colony/modules/http.js
+++ b/src/colony/modules/http.js
@@ -179,14 +179,15 @@ function ServerRequest (connection) {
   })
   this.connection.on('data', function (data) {
     data = data.toString('utf8');
-    // console.log('received', data.length, data.substr(0, 15));
     parser.execute(data, 0, data.length);
   })
 }
 
 util.inherits(ServerRequest, Readable);
 
-
+ServerRequest.prototype._read = function(size){
+  // no-op
+}
 
 
 function HTTPServer () {


### PR DESCRIPTION
fixes this https://forums.tessel.io/t/why-does-a-call-to-on-data-throw-an-error-not-implemented/710/4
