### PR TITLE
Normalizes all tests to use the tap module.

### DIFF
--- a/src/posix/tm_net.c
+++ b/src/posix/tm_net.c
@@ -171,6 +171,11 @@ int tm_tcp_listen (tm_socket_t sock, uint16_t port)
   localSocketAddr.sin_port = htons(port);
   localSocketAddr.sin_addr.s_addr = 0;
 
+  // Allow port to be re-bound even in TIME_WAIT state.
+  // http://stackoverflow.com/questions/3229860/what-is-the-meaning-of-so-reuseaddr-setsockopt-option-linux
+  int optval = 1;
+  setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof optval);
+
   // Bind socket
   // TM_COMMAND('w', "Binding local socket...");
   int sockStatus;

--- a/test/issues/issue-beta-100.js
+++ b/test/issues/issue-beta-100.js
@@ -1,5 +1,9 @@
+var tap = require('../tap');
+
+tap.count(1);
+
 var arr =  [ 0, 13, 2, 1, 21, 0, 0, 0, 0, 0, 6, 104, 105, 32, 106, 111, 110 ];
 var val = arr.slice(7);
-console.log('1..1');
-console.log(val.length == 10 ? 'ok' : 'not ok');
+
+tap.eq(val.length, 10);
 console.log('#', val);

--- a/test/issues/issue-beta-101.js
+++ b/test/issues/issue-beta-101.js
@@ -1,7 +1,11 @@
+var tap = require('../tap');
+
+tap.count(2);
+
 var arr =  [ 0, 13, 2, 1, 21, 0, 0, 0, 0, 0, 6, 104, 105, 32, 106, 111, 110 ];
 var val = new Buffer(arr).slice(7);
-console.log('1..2')
-console.log(val.length == 10 ? 'ok' : 'not ok');
+
+tap.eq(val.length, 10);
 console.log('#', val);
-console.log(new Buffer('hello').toString() == 'hello' ? 'ok' : 'not ok')
+tap.eq(new Buffer('hello').toString(), 'hello');
 console.log('#', new Buffer('hello').toString())

--- a/test/issues/issue-beta-108.js
+++ b/test/issues/issue-beta-108.js
@@ -1,9 +1,12 @@
+var tap = require('../tap');
+
+tap.count(1);
+
 var arr = [];
 
-console.log('1..1')
 for (var i in arr) {
-	console.log('#', i);
-	console.log('not ok', '- Array should not have found index', i)
+  console.log('#', i);
+  tap.ok(false, 'Array should not have found index');
   process.exit(1);
 }
-console.log('ok')
+tap.ok(true);

--- a/test/issues/issue-beta-131.js
+++ b/test/issues/issue-beta-131.js
@@ -1,4 +1,6 @@
-console.log('1..1')
+var tap = require('../tap');
+
+tap.count(1);
 
 a = function () { }
 
@@ -12,4 +14,4 @@ a.b = true
 
 // ; ;
 
-console.log('ok')
+tap.ok(true)

--- a/test/issues/issue-beta-140.js
+++ b/test/issues/issue-beta-140.js
@@ -1,7 +1,6 @@
-/* test rig */ var t = 1, tmax = 3
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
+
+tap.count(3);
 
 function arreq (a, b) {
 	if (a.length != b.length) {
@@ -15,12 +14,11 @@ function arreq (a, b) {
 	return true;
 }
 
-
 var header = [0x02, 0x02, 0x00];
 var data = new Array(0x02);
-ok(header.concat(data).length == 5, 'array concat length')
+tap.ok(header.concat(data).length == 5, 'array concat length')
 console.log('# -->', header.concat(data).length)
-ok(arreq(header.concat(data), [2, 2, 0, undefined, undefined]), 'array concat')
+tap.ok(arreq(header.concat(data), [2, 2, 0, undefined, undefined]), 'array concat')
 console.log('#', header.concat(data))
-ok([2, 2, 0, undefined, undefined].length == 5, 'array length');
+tap.ok([2, 2, 0, undefined, undefined].length == 5, 'array length');
 console.log('#', [2, 2, 0, undefined, undefined].length);

--- a/test/issues/issue-beta-148.js
+++ b/test/issues/issue-beta-148.js
@@ -1,6 +1,9 @@
-console.log('1..1');
+var tap = require('../tap');
+
+tap.count(1);
+
 var b = new Date()
 var a = +b
-console.log(a == b.valueOf() ? 'ok' : 'not ok', 1);
+tap.eq(a, b.valueOf());
 console.log('#', a)
 console.log('#', b.valueOf())

--- a/test/issues/issue-beta-159.js
+++ b/test/issues/issue-beta-159.js
@@ -1,12 +1,14 @@
 // Strings should not automatically be coerced to numbers in arithmetic
 // but tonumber() should continue to coerce strings
 
-console.log('1..2')
+var tap = require('../tap');
+
+tap.count(2);
 
 var elem = "2";
-console.log(("0" + elem) == '02' ? 'ok' : 'not ok', 1)
+tap.eq("0" + elem, '02');
 console.log('#', '0' + elem)
 
 var n = Number("55");
-console.log(n == 55 ? 'ok' : 'not ok', 2);
+tap.eq(n, 55);
 console.log('#', n);

--- a/test/issues/issue-beta-170.js
+++ b/test/issues/issue-beta-170.js
@@ -1,7 +1,6 @@
-/* test rig */ var t = 1, tmax = 2
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
 
-ok(a, 'function is hoisted');
+tap.count(1);
+
+tap.ok(a, 'function is hoisted');
 function a () { }

--- a/test/issues/issue-beta-179.js
+++ b/test/issues/issue-beta-179.js
@@ -1,5 +1,6 @@
-console.log('1..2');
-var i = 0;
+var tap = require('../tap');
+
+tap.count(2);
 
 var util = require('util');
 var events = require('events');
@@ -20,18 +21,18 @@ c.once('booted', bootSequence.bind(c));
 
 function bootSequence(data) {
   setImmediate(function() {
-    console.log(data, ++i, '-', this.name);
+    tap.ok(data, this.name);
   }.bind(this));
 }
 
-t.emit('booted', 'ok');
+t.emit('booted', true);
 
-c.emit('booted', 'ok');
+c.emit('booted', true);
 
 console.log('# no more not oks');
 
-t.emit('booted', 'not ok');
+t.emit('booted', false);
 
-c.emit('booted', 'not ok');
+c.emit('booted', false);
 
-t.emit('booted', 'not ok');
+t.emit('booted', false);

--- a/test/issues/issue-beta-180.js
+++ b/test/issues/issue-beta-180.js
@@ -1,3 +1,7 @@
+var tap = require('../tap');
+
+tap.count(1);
+
 var b = 0;
 function a () {
 	return b = 5; 
@@ -9,5 +13,5 @@ console.log((b = {a: 5}).a);
 // test[a]();
 
 var i = { length : 1 };
-var task = [function () { console.log(this == task ? 'ok' : 'not ok'); }]
+var task = [function () { tap.eq(this, task); }]
 task[i.length - 1]();

--- a/test/issues/issue-beta-195.js
+++ b/test/issues/issue-beta-195.js
@@ -1,21 +1,20 @@
-/* test rig */ var t = 1, tmax = 6
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
+
+tap.count(5);
 
 var table = [];
 table["0"] = true;
-ok(table["0"] == true)
-ok(table[0] == true)
+tap.ok(table["0"] == true)
+tap.ok(table[0] == true)
 
 var table = {};
 table[0] = true;
-ok(table["0"] == true)
-ok(table[0] == true)
+tap.ok(table["0"] == true)
+tap.ok(table[0] == true)
 
 var table = {};
 table[5] = true;
-ok(table["5"] == true)
+tap.ok(table["5"] == true)
 
 var table = {};
 table[function hi() { }] = true

--- a/test/issues/issue-beta-200.js
+++ b/test/issues/issue-beta-200.js
@@ -1,7 +1,9 @@
-console.log('1..2')
+var tap = require('../tap');
+
+tap.count(2);
 
 var d = [3,2,1];
-if (!d) console.log("not ok -", d); else console.log('ok')
+tap.ok(d);
 
 var _d = [1,2,3];
-if (!_d) console.log("not ok -", _d); else console.log('ok')
+tap.ok(_d);

--- a/test/issues/issue-beta-204.js
+++ b/test/issues/issue-beta-204.js
@@ -1,9 +1,9 @@
-/* test rig */ var t = 1, tmax = 2
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
+
+tap.count(2);
 
 var s = '42',
     n = +s;
-ok(n == 42, typeof n == 'number');
+tap.ok(n, 42);
+tap.eq(typeof n, 'number');
 console.log('#', n, typeof n);

--- a/test/issues/issue-beta-212.js
+++ b/test/issues/issue-beta-212.js
@@ -1,26 +1,25 @@
-/* test rig */ var t = 1, tmax = 2
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
+
+tap.count(8);
 
 var n = 42;
-ok(n.toString(10) == '42')
+tap.ok(n.toString(10) == '42')
 console.log("# base 10:", JSON.stringify(n.toString(10)));
-ok(n.toString(16) == '2a')
+tap.ok(n.toString(16) == '2a')
 console.log("# base 16:", JSON.stringify(n.toString(16)));
-ok(n.toString(2) == '101010')
+tap.ok(n.toString(2) == '101010')
 console.log("# base  2:", JSON.stringify(n.toString(2)));
-ok(n.toString(24) == '1i')
+tap.ok(n.toString(24) == '1i')
 console.log("# base 24:", JSON.stringify(n.toString(24)));
 
 console.log()
 
 // stress test invalid radixes
-try { n.toString(1); console.log('not ok'); }
-catch (e) { console.log('ok'); }
-try { n.toString(0); console.log('not ok'); }
-catch (e) { console.log('ok'); }
-try { n.toString(37); console.log('not ok'); }
-catch (e) { console.log('ok'); }
-try { n.toString("1"); console.log('not ok'); }
-catch (e) { console.log('ok'); }
+try { n.toString(1); tap.ok(false); }
+catch (e) { tap.ok(e); }
+try { n.toString(0); tap.ok(false); }
+catch (e) { tap.ok(e); }
+try { n.toString(37); tap.ok(false); }
+catch (e) { tap.ok(e); }
+try { n.toString("1"); tap.ok(false); }
+catch (e) { tap.ok(e); }

--- a/test/issues/issue-beta-213.js
+++ b/test/issues/issue-beta-213.js
@@ -1,20 +1,19 @@
-/* test rig */ var t = 1, tmax = 5
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
+
+tap.count(7);
 
 var n = 0xF0F0F0F0E1;
-ok(String(n) == '1034834473185');
-ok(n.toString(10) == '1034834473185');
+tap.ok(String(n) == '1034834473185');
+tap.ok(n.toString(10) == '1034834473185');
 console.log("# base 10:", n.toString(10), '==', '1034834473185');
-ok(n.toString(16) == 'f0f0f0f0e1');
+tap.ok(n.toString(16) == 'f0f0f0f0e1');
 console.log("# base 16:", n.toString(16), '==', 'f0f0f0f0e1');
 
 var n = 1034834473185;
-ok(String(n) == '1034834473185');
-ok(n.toString(10) == '1034834473185');
+tap.ok(String(n) == '1034834473185');
+tap.ok(n.toString(10) == '1034834473185');
 console.log('# base 10:', n.toString(10), '==', '1034834473185');
-ok(n.toString(16) == 'f0f0f0f0e1');
+tap.ok(n.toString(16) == 'f0f0f0f0e1');
 console.log('# base 16:', n.toString(16), '==', 'f0f0f0f0e1');
 
-ok((0xFFFFFFFF * 2) > 0xFFFFFFFF, "supports > 0xFFFFFFFF")
+tap.ok((0xFFFFFFFF * 2) > 0xFFFFFFFF, "supports > 0xFFFFFFFF")

--- a/test/issues/issue-beta-221.js
+++ b/test/issues/issue-beta-221.js
@@ -1,13 +1,12 @@
-/* test rig */ var t = 1, tmax = 3
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
+
+tap.count(2);
 
 try {
 	throw Error("Test");
-	ok(false)
+	tap.ok(false)
 } catch (e) {
-	ok(true)
+	tap.ok(true)
 }
 
-ok(Error("Test").message)
+tap.ok(Error("Test").message)

--- a/test/issues/issue-beta-243.js
+++ b/test/issues/issue-beta-243.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
 
-console.log('1..1');
-console.log('ok');
+var tap = require('../tap');
+
+tap.count(1);
+tap.ok(true);

--- a/test/issues/issue-beta-244.js
+++ b/test/issues/issue-beta-244.js
@@ -1,6 +1,9 @@
+var tap = require('../tap');
+
+tap.count(2);
+
 var json = JSON.parse('{"1":true,"one":true}');
 
-console.log('1..2')
-console.log(json[1] ? 'ok' : 'not ok');
-console.log(json['one'] ? 'ok' : 'not ok');
+tap.ok(json[1]);
+tap.ok(json['one']);
 console.log('#', json)

--- a/test/issues/issue-beta-245.js
+++ b/test/issues/issue-beta-245.js
@@ -1,7 +1,6 @@
-/* test rig */ var t = 1, tmax = 2
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
+
+tap.count(1);
 
 var l = [,1];
-ok(l[1] == 1, 'empty elements allowed');
+tap.eq(l[1], 1, 'empty elements allowed');

--- a/test/issues/issue-beta-251.js
+++ b/test/issues/issue-beta-251.js
@@ -1,4 +1,6 @@
-console.log('1..1');
+var tap = require('../tap');
+
+tap.count(1);
 
 console.log('#', new Buffer([0x35]) + '67');
-console.log(new Buffer([0x35]) + '67' == '\x3567' ? 'ok' : 'not ok')
+tap.eq(new Buffer([0x35]) + '67', '\x3567');

--- a/test/issues/issue-beta-274.js
+++ b/test/issues/issue-beta-274.js
@@ -1,8 +1,6 @@
-/* TAP rig */
-function tap (max) { tap.t = 1; console.log(tap.t + '..' + max); };
-function ok (a, d) { console.log((a ? '' : 'not ') + 'ok', tap.t++, '-', d); }
+var tap = require('../tap');
 
-tap(2);
+tap.count(2);
 
-ok(2^16 == 16, 'bitwise xor')
-ok(2^16 != 65536, 'not exponent')
+tap.ok(2^16 == 16, 'bitwise xor')
+tap.ok(2^16 != 65536, 'not exponent')

--- a/test/issues/issue-beta-276.js
+++ b/test/issues/issue-beta-276.js
@@ -1,11 +1,9 @@
-console.log('1..3')
+var tap = require('../tap');
+
+tap.count(2);
 
 var a = new Date();
-console.log(new Date() - new Date() == 0 ? 'ok' : 'not ok', '#SKIP')
-
-var a = new Date()
-var b = new Date()
-console.log(a - b == 0 ? 'ok' : 'not ok', '#SKIP')
+tap.eq(a - a, 0);
 
 var a = new Date();
 var a_val = Number(a);
@@ -14,4 +12,4 @@ var b = {
 		return a_val - 1000;
 	}
 }
-console.log(a - b == 1000 ? 'ok' : 'not ok')
+tap.eq(a - b, 1000);

--- a/test/issues/issue-beta-294.js
+++ b/test/issues/issue-beta-294.js
@@ -1,4 +1,7 @@
-console.log('1..1')
+var tap = require('../tap');
+
+tap.count(1);
+
 var b = [], c = 0, d = 0;
 a = b[++c] = d;
-console.log('ok')
+tap.ok(true);

--- a/test/issues/issue-beta-296.js
+++ b/test/issues/issue-beta-296.js
@@ -1,7 +1,11 @@
-console.log('1..3')
+var tap = require('../tap');
+
+tap.count(3);
+
+
 var b = { $super: {} };
 var c = b.$super.init;
-console.log('ok');
+tap.ok(true);
 
 a: {
 	if (true) {
@@ -9,7 +13,7 @@ a: {
 	}
 }
 
-console.log('ok');
+tap.ok(true);
 
 
 function inheritAsync () {
@@ -22,4 +26,4 @@ function inheritAsync () {
     }
 };
 
-console.log('ok')
+tap.ok(true);

--- a/test/issues/issue-beta-314.js
+++ b/test/issues/issue-beta-314.js
@@ -1,4 +1,6 @@
-console.log('1..1');
+var tap = require('../tap');
+
+tap.count(1);
 
 var dict = {};
 var a = {len: 1, arr: []};
@@ -9,4 +11,4 @@ dict['2'] = c;
 dict['0'] = a;
 console.log('#', dict)
 console.log('#', Object.keys(dict))
-console.log(Object.keys(dict).length > 1 ? 'ok' : 'not ok');
+tap.ok(Object.keys(dict).length > 1);

--- a/test/issues/issue-beta-317.js
+++ b/test/issues/issue-beta-317.js
@@ -1,8 +1,6 @@
-/* TAP rig */
-function tap (max) { tap.t = 1; console.log(tap.t + '..' + max); };
-function ok (a, d) { console.log((a ? '' : 'not ') + 'ok', tap.t++, '-', d); }
+var tap = require('../tap');
 
-tap(3);
+tap.count(3);
 
 var dict = {};
 dict['1'] = 1;
@@ -11,6 +9,6 @@ dict['0x10'] = 3;
 dict['a'] = 4;
 // console.log(dict, Object.keys(dict), dict['1'], dict['0x10'], dict['16']);
 
-ok(dict['1'] == 1)
-ok(Object.keys(dict).map(String).indexOf('01') > 0)
-ok(Object.keys(dict).map(String).indexOf('0x10') > 0)
+tap.ok(dict['1'] == 1)
+tap.ok(Object.keys(dict).map(String).indexOf('01') > 0)
+tap.ok(Object.keys(dict).map(String).indexOf('0x10') > 0)

--- a/test/issues/issue-beta-319.js
+++ b/test/issues/issue-beta-319.js
@@ -1,19 +1,17 @@
-/* TAP rig */
-function tap (max) { tap.t = 1; console.log(tap.t + '..' + max); };
-function ok (a, d) { console.log((a ? '' : 'not ') + 'ok', tap.t++, '-', d); }
+var tap = require('../tap');
 
-tap(3);
+tap.count(3);
 
 var simpleQueue = new Array();
 
 simpleQueue.pushItem = function(item) {
   this.push(item);
-  ok(this.length == 2, "Length should be 2: " + this.length);
+  tap.ok(this.length == 2, "Length should be 2: " + this.length);
 };
 
 console.log('well', simpleQueue.length)
 simpleQueue.push(1);
-ok(simpleQueue.length == 1);
+tap.ok(simpleQueue.length == 1);
 
 simpleQueue.pushItem('foo');
 
@@ -21,4 +19,4 @@ var b = new Array();
 b[0] = 5;
 b[1] = 5;
 b.push(1);
-ok(b.length == 3);
+tap.ok(b.length == 3);

--- a/test/issues/issue-beta-327.js
+++ b/test/issues/issue-beta-327.js
@@ -1,4 +1,6 @@
-console.log('1..1')
+var tap = require('../tap');
+
+tap.count(1);
 
 require('tls')
-console.log('ok');
+tap.ok(true);

--- a/test/issues/issue-beta-334.js
+++ b/test/issues/issue-beta-334.js
@@ -1,39 +1,37 @@
-/* TAP rig */
-function tap (max) { tap.t = 1; console.log(tap.t + '..' + max); };
-function ok (a, d) { console.log((a ? '' : 'not ') + 'ok', tap.t++, '-', d); }
+var tap = require('../tap');
 
-tap(11);
+tap.count(11);
 
 var buf = new Buffer(4);
 
 buf.writeUInt32BE(0xdeadbeef, 0);
-ok(buf[0] == 0xde, 'UInt32');
-ok(buf[1] == 0xad, 'UInt32');
-ok(buf[2] == 0xbe, 'UInt32');
-ok(buf[3] == 0xef, 'UInt32');
+tap.ok(buf[0] == 0xde, 'UInt32');
+tap.ok(buf[1] == 0xad, 'UInt32');
+tap.ok(buf[2] == 0xbe, 'UInt32');
+tap.ok(buf[3] == 0xef, 'UInt32');
 buf.fill(0);
 
 try {
 	buf.writeUInt32LE(0xdeadbeef, 2);
-	ok(false, 'error not thrown by out of bounds write')
+	tap.ok(false, 'error not thrown by out of bounds write')
 } catch (e) {
-	ok(true, 'error thrown by out of bounds write')
+	tap.ok(true, 'error thrown by out of bounds write')
 }
 
 try {
 	buf.writeUInt32LE(0xdeadbeef, 2, true);
-	ok(true, 'error not thrown by out of bounds write')
+	tap.ok(true, 'error not thrown by out of bounds write')
 } catch (e) {
-	ok(false, 'error thrown by out of bounds write')
+	tap.ok(false, 'error thrown by out of bounds write')
 }
-ok(buf[2] == 0xef, 'out of bounds write still writes');
-ok(buf[3] == 0xbe, 'out of bounds write still writes');
+tap.ok(buf[2] == 0xef, 'out of bounds write still writes');
+tap.ok(buf[3] == 0xbe, 'out of bounds write still writes');
 
 try {
 	buf.readUInt32LE(2);
-	ok(false, 'error not thrown by out of bounds read')
+	tap.ok(false, 'error not thrown by out of bounds read')
 } catch (e) {
-	ok(true, 'error thrown by out of bounds write')
+	tap.ok(true, 'error thrown by out of bounds write')
 }
 
 buf[0] = 0;
@@ -41,10 +39,10 @@ buf[1] = 0;
 buf[2] = 0xFF;
 buf[3] = 0xFF;
 var value = buf.readUInt32LE(0, true);
-ok(value == 4294901760, 'in bounds write succeeds')
+tap.ok(value == 4294901760, 'in bounds write succeeds')
 try {
 	var value = buf.readUInt32LE(2, true);
-	ok(value == 65535, 'out of bounds write succeeds')
+	tap.ok(value == 65535, 'out of bounds write succeeds')
 } catch (e) {
-	console.log('not ok')
+	tap.ok(false);
 }

--- a/test/issues/issue-beta-338.js
+++ b/test/issues/issue-beta-338.js
@@ -1,9 +1,7 @@
-/* TAP rig */
-function tap (max) { tap.t = 1; console.log(tap.t + '..' + max); };
-function ok (a, d) { console.log((a ? '' : 'not ') + 'ok', tap.t++, '-', d); }
+var tap = require('../tap');
 
-tap(1);
+tap.count(1);
 
 var b = Buffer([1,2,3]).slice(3,50);
 console.log('#', b);
-ok(b.length == 0, 'buffer.slice does not read past end.');
+tap.eq(b.length, 0, 'buffer.slice does not read past end.');

--- a/test/issues/issue-beta-339.js
+++ b/test/issues/issue-beta-339.js
@@ -1,9 +1,7 @@
-/* TAP rig */
-function tap (max) { tap.t = 1; console.log(tap.t + '..' + max); };
-function ok (a, d) { console.log((a ? '' : 'not ') + 'ok', tap.t++, '-', d); }
+var tap = require('../tap');
 
-tap(1);
+tap.count(1);
 
 var b = Buffer([1,2,3,4,5,6]).slice(1,-2);
 console.log('#', b);
-ok(b.length == 3, 'buffer.slice accepts negative indices');
+tap.eq(b.length, 3, 'buffer.slice accepts negative indices');

--- a/test/issues/issue-beta-340.js
+++ b/test/issues/issue-beta-340.js
@@ -1,24 +1,17 @@
-// Any copyright is dedicated to the Public Domain.
-// http://creativecommons.org/publicdomain/zero/1.0/
+var tap = require('../tap');
 
-/* test rig */
-function tap (max) { tap.t = 1; console.log(tap.t + '..' + max); };
-function ok (a, d) { console.log((a ? '' : 'not ') + 'ok', tap.t++, '-', d); }
-
-/* script */
-
-tap(2);
+tap.count(2);
 
 console.log('#', 0 && true)
-ok(!(0 && true), '0 should short-circuit truthiness');
+tap.ok(!(0 && true), '0 should short-circuit truthiness');
 
 var a = 0;
 console.log('#', a && true)
-ok(!(a && true), '0 var should short-circuit truthiness');
+tap.ok(!(a && true), '0 var should short-circuit truthiness');
 
 console.log('#', 0 || 42)
-ok((0 || 42) == 42, '0 should short-circuit falsiness');
+tap.ok((0 || 42) == 42, '0 should short-circuit falsiness');
 
 var a = 0;
 console.log('#', a || 42)
-ok((a || 42) == 42, '0 var should short-circuit falsiness');
+tap.ok((a || 42) == 42, '0 var should short-circuit falsiness');

--- a/test/issues/issue-beta-342.js
+++ b/test/issues/issue-beta-342.js
@@ -1,35 +1,37 @@
-console.log('1..6');
+var tap = require('../tap');
+
+tap.count(6);
 
 var arg = "Hello Friends";
 var ret = Buffer.concat( [ arg ] );
-console.log(arg === ret ? 'ok' : 'not ok');
+tap.eq(arg, ret);
 
 try { 
 	Buffer.concat( [ arg, arg ] );
-	console.log('not ok');
+	tap.ok(false);
 } catch (e) {
-	console.log('ok');
+	tap.ok(e);
 }
 
 var a = new Buffer(16);
 var b = new Buffer(16);
 a.copy(b, 256, 0, 0);
-console.log('ok');
+tap.ok(true);
 
 var rando = new Buffer(16);
 Buffer.concat([rando, rando], 32);
 Buffer.concat([rando, rando], 31);
 Buffer.concat([rando, rando], 128);
-console.log('ok')
+tap.ok(true);
 try {
 	Buffer.concat([rando, rando], 8)
-	console.log('not ok');
+	tap.ok(false);
 } catch (e) {
-	console.log('ok');
+	tap.ok(e);
 }
 
 try {
 	Buffer.concat()
 } catch (e) {
-	console.log('ok -', String(e));
+	tap.ok(e);
 }

--- a/test/issues/issue-beta-351.js
+++ b/test/issues/issue-beta-351.js
@@ -1,5 +1,7 @@
-console.log('1..1');
+var tap = require('../tap');
+
+tap.count(1);
 
 var a = [];
 a.push('foo');
-console.log(a.pop() == 'foo' ? 'ok' : 'not ok');
+tap.eq(a.pop(), 'foo');

--- a/test/issues/issue-beta-352.js
+++ b/test/issues/issue-beta-352.js
@@ -1,5 +1,8 @@
-console.log('1..4');
-console.log([1,2,3].join() == '1,2,3' ? 'ok' : 'not ok');
-console.log([1,2,3].join('###') == '1###2###3' ? 'ok' : 'not ok');
-console.log([1,2,3].join(1) == '11213' ? 'ok' : 'not ok');
-console.log([1,2,3].join(null) == '1null2null3' ? 'ok' : 'not ok');
+var tap = require('../tap');
+
+tap.count(4);
+
+tap.eq([1,2,3].join(), '1,2,3');
+tap.eq([1,2,3].join('###'), '1###2###3');
+tap.eq([1,2,3].join(1), '11213');
+tap.eq([1,2,3].join(null), '1null2null3');

--- a/test/issues/issue-beta-356.js
+++ b/test/issues/issue-beta-356.js
@@ -1,5 +1,7 @@
-console.log('1..1');
+var tap = require('../tap');
+
+tap.count(1);
 
 process.nextTick(function () {
-	console.log('ok');
+	tap.ok(true);
 });

--- a/test/issues/issue-beta-366.js
+++ b/test/issues/issue-beta-366.js
@@ -1,7 +1,9 @@
-console.log('1..1');
+var tap = require('../tap');
+
+tap.count(3);
+
 parseInt(null, 16)
 console.log('#', parseInt(null, 16))
-console.log(isNaN(parseInt(null, 10)) ? 'ok' : 'not ok')
-console.log(isNaN(parseInt(null, 16)) ? 'ok' : 'not ok')
-console.log(parseInt(null, 32) == 785077 ? 'ok' : 'not ok', parseInt(null, 32))
-console.log('ok')
+tap.ok(isNaN(parseInt(null, 10)));
+tap.ok(isNaN(parseInt(null, 16)));
+tap.eq(parseInt(null, 32), 785077);

--- a/test/issues/issue-beta-379.js
+++ b/test/issues/issue-beta-379.js
@@ -1,4 +1,7 @@
-console.log('1..3');
-console.log(Buffer([255]).readUInt32BE(0, true).toString(16) == 'ff000000' ? 'ok' : 'not ok');
-console.log(Buffer(0).readUInt32BE(9999, true) == 0 ? 'ok' : 'not ok');
-console.log(Buffer(0).readUInt8(9999, true) == undefined ? 'ok' : 'not ok');
+var tap = require('../tap');
+
+tap.count(3);
+
+tap.eq(Buffer([255]).readUInt32BE(0, true).toString(16), 'ff000000');
+tap.eq(Buffer(0).readUInt32BE(9999, true), 0);
+tap.eq(Buffer(0).readUInt8(9999, true), undefined);

--- a/test/issues/issue-beta-380.js
+++ b/test/issues/issue-beta-380.js
@@ -1,7 +1,10 @@
-console.log('1..2')
+var tap = require('../tap');
+
+tap.count(2);
+
 var b = Buffer(20),
     s = b.fill(0xFF) || b.slice(5,15);
 b.fill(0);
-console.log(s.toString('hex') == '00000000000000000000' ? 'ok' : 'not ok');
+tap.eq(s.toString('hex'), '00000000000000000000');
 s.fill(42);
-console.log(b.toString('hex') == '00000000002a2a2a2a2a2a2a2a2a2a0000000000' ? 'ok' : 'not ok');
+tap.eq(b.toString('hex'), '00000000002a2a2a2a2a2a2a2a2a2a0000000000');

--- a/test/issues/issue-beta-390.js
+++ b/test/issues/issue-beta-390.js
@@ -1,6 +1,8 @@
-var test = {};
+var tap = require('../tap');
 
-console.log('1..1');
+tap.count(3);
+
+var test = {};
 
 test['A'] = 0;
 Object.defineProperty(test, 'a', {
@@ -9,6 +11,6 @@ Object.defineProperty(test, 'a', {
 
 test['B'] = 1;
 console.log('# test', test);
-console.log(Object.keys(test).indexOf('B') > -1 ? 'ok' : 'not ok');
-console.log('B' in test ? 'ok' : 'not ok')
-console.log(test.a == 0 ? 'ok' : 'not ok')
+tap.ok(Object.keys(test).indexOf('B') > -1);
+tap.ok('B' in test);
+tap.eq(test.a, 0);

--- a/test/issues/issue-beta-394.js
+++ b/test/issues/issue-beta-394.js
@@ -1,4 +1,6 @@
-console.log('1..5');
+var tap = require('../tap');
+
+tap.count(5);
 
 var a = {};
 
@@ -6,40 +8,40 @@ Object.defineProperty(a, 'hello', {
 	value: 'hi'
 })
 
-console.log(a.hello == 'hi' ? 'ok' : 'not ok');
+tap.eq(a.hello, 'hi');
 
 try {
 	Object.defineProperty(null, 'hello', {
 		value: 'hi'
 	})
-	console.log('not ok');
+	tap.ok(false);
 } catch (e) {
-	console.log('ok');
+	tap.ok(true);
 }
 
 try {
 	Object.defineProperty('', 'hello', {
 		value: 'hi'
 	})
-	console.log('not ok');
+	tap.ok(false);
 } catch (e) {
-	console.log('ok', '#', e);
+	tap.ok(e);
 }
 
 try {
 	Object.defineProperty(0, 'hello', {
 		value: 'hi'
 	})
-	console.log('not ok');
+	tap.ok(false);
 } catch (e) {
-	console.log('ok');
+	tap.ok(e);
 }
 
 try {
 	Object.defineProperty(true, 'hello', {
 		value: 'hi'
 	})
-	console.log('not ok');
+	tap.ok(false);
 } catch (e) {
-	console.log('ok');
+	tap.ok(e);
 }

--- a/test/issues/issue-beta-395.js
+++ b/test/issues/issue-beta-395.js
@@ -1,11 +1,13 @@
-console.log('1..2');
+var tap = require('../tap');
+
+tap.count(2);
 
 var a = ['c', 'd', 'a', 'e', 'b']
 console.log('#', a);
 
 var b = a.slice()
 console.log('#', b.sort());
-console.log(JSON.stringify(b) == JSON.stringify(['a', 'b', 'c', 'd', 'e']) ? 'ok' : 'not ok');
+tap.eq(JSON.stringify(b), JSON.stringify(['a', 'b', 'c', 'd', 'e']))
 
 b.sort().push('hi');
-console.log(b.pop() == 'hi' ? 'ok' : 'not ok')
+tap.eq(b.pop(), 'hi');

--- a/test/issues/issue-beta-402.js
+++ b/test/issues/issue-beta-402.js
@@ -1,1 +1,7 @@
+var tap = require('../tap');
+
+tap.count(1);
+
 var a = /^\s*$/;
+
+tap.ok(true);

--- a/test/issues/issue-beta-440.js
+++ b/test/issues/issue-beta-440.js
@@ -1,4 +1,6 @@
-console.log('1..1');
+var tap = require('../tap');
+
+tap.count(1);
 
 var arr = [{a:1}, {a:6},{a:2}, {a:4}]
 arr.sort(function(a, b) {
@@ -8,4 +10,5 @@ arr.sort(function(a, b) {
 
 arr.sort();
 
-console.log('ok');
+tap.ok(true);
+

--- a/test/issues/issue-beta-446.js
+++ b/test/issues/issue-beta-446.js
@@ -1,4 +1,6 @@
-console.log('1..2');
+var tap = require('../tap');
+
+tap.count(2);
 
 var str = 'DNS:*.github.com, DNS:github.com';
 
@@ -10,6 +12,6 @@ var a = /a(b)|c/g;
 'abc'.replace(a, function (all, sub) {
 	console.log('#', all, sub);
 	if (all == 'c') {
-		console.log(sub == null ? 'ok' : 'not ok')
+		tap.eq(sub, null);
 	}
 })

--- a/test/issues/issue-beta-451.js
+++ b/test/issues/issue-beta-451.js
@@ -1,11 +1,8 @@
-/* TAP rig */
-function tap (max) { tap.t = 1; console.log(tap.t + '..' + max); };
-function ok (a, d) { console.log((a ? '' : 'not ') + 'ok', tap.t++, '-', d); }
-function eq (a, b, c) { ok(a == b, String(c) + ': ' + String(a) + ' == ' + String(b)); }
+var tap = require('../tap');
 
-tap(1);
+tap.count(1);
 
 var obj = {};
 console.log("# obj.__proto__ =", obj.__proto__);
 console.log("# Object.getPrototypeOf(obj) =", Object.getPrototypeOf(obj));
-eq(obj.__proto__, Object.getPrototypeOf(obj), 'same prototype');
+tap.eq(obj.__proto__, Object.getPrototypeOf(obj), 'same prototype');

--- a/test/issues/issue-beta-77.js
+++ b/test/issues/issue-beta-77.js
@@ -1,3 +1,7 @@
+var tap = require('../tap');
+
+tap.count(1);
+
 function TestObj() {}
 
 var globalDict = {};
@@ -6,5 +10,4 @@ var t = new TestObj();
 
 globalDict[t] = "hi";
 
-console.log('1..1')
-console.log(JSON.stringify(globalDict) == '{"[object Object]":"hi"}' ? 'ok' : 'not ok');
+tap.eq(JSON.stringify(globalDict), '{"[object Object]":"hi"}');

--- a/test/issues/issue-beta-81.js
+++ b/test/issues/issue-beta-81.js
@@ -1,14 +1,12 @@
-/* test rig */ var t = 1, tmax = 2
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
 
+tap.count(2);
 
 var actions = ["a", "b", "c", "d", "e", "f", "g"];
 var _n = 1;
-ok(actions[_n] == 'b', 'underscores in member properties not undefined');
+tap.ok(actions[_n] == 'b', 'underscores in member properties not undefined');
 var _j = {_k: 5}
-ok(actions[_j._k] == 'f', 'underscores in member properties in member properties not undefined');
+tap.ok(actions[_j._k] == 'f', 'underscores in member properties in member properties not undefined');
 
 // var actions = ["a", "b", "c", "d", "e", "f", "g"];
 // for (_n in actions) {

--- a/test/issues/issue-beta-84.js
+++ b/test/issues/issue-beta-84.js
@@ -1,20 +1,22 @@
-console.log('1..7')
+var tap = require('../tap');
+
+tap.count(7);
 
 function MyObject(name){
     this.name = name;
 }
 MyObject.prototype.yo = function(){
-    console.log("ok Greetings from " + this.name);
+    tap.ok(true, "Greetings from " + this.name);
 }
 var o = new MyObject("adrian");
-console.log("ok original", o);
+tap.ok(o, "original");
 o.yo();
 
 var i = Object(o);
-console.log("ok Object()", i);
+tap.ok(i, "Object()");
 i.name = "zankich";
 i.yo();
 o.yo();
 
-console.log("ok Object()", i);
-console.log("ok original", o);
+tap.ok(i, "Object()");
+tap.ok(o, "original");

--- a/test/issues/issue-beta-87.js
+++ b/test/issues/issue-beta-87.js
@@ -1,4 +1,8 @@
-console.log('1..1');
+var tap = require('../tap');
+
+tap.count(1);
+
 console.log(true << 1);
 console.log(+true << 1);
-console.log('ok')
+
+tap.ok(true);

--- a/test/issues/issue-beta-93.js
+++ b/test/issues/issue-beta-93.js
@@ -1,7 +1,10 @@
+var tap = require('../tap');
+
+tap.count(1);
+
 function MyObject(name){
   this.name = name;
 }
 var o = new MyObject("adrian");
 var a = [].concat(o);
-console.log(a);
-console.log('ok')
+tap.eq(String(a), '[object Object]');

--- a/test/issues/issue-beta-97.js
+++ b/test/issues/issue-beta-97.js
@@ -1,8 +1,6 @@
-/* test rig */ var t = 1, tmax = 2
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
 
+tap.count(2);
 
 function MyObject(name){
     this.name = name;
@@ -17,5 +15,5 @@ MyObject.prototype.yo = function(){
 var o = new MyObject("adrian");
 o.yo();
 
-ok(o.constructor, "o.constructor");
-ok(o.constructor.booyakasha() == 'Hear me now!', "o.constructor.booyakasha()");
+tap.ok(o.constructor, "o.constructor");
+tap.eq(o.constructor.booyakasha(), 'Hear me now!', "o.constructor.booyakasha()");

--- a/test/issues/issue-beta-98.js
+++ b/test/issues/issue-beta-98.js
@@ -1,12 +1,11 @@
-/* test rig */ var t = 1, tmax = 4
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
+
+tap.count(3);
 
 var arr = [];
-ok(arr.length == 0, 'array [] len 0')
+tap.eq(arr.length, 0, 'array [] len 0')
 arr.hello = 'hi';
-ok(arr.length == 0, 'array keys constant')
+tap.eq(arr.length, 0, 'array keys constant')
 
 arr.push(1, 2, 3, 4, 5);
-ok(arr[0] == 1, 'array key set');
+tap.eq(arr[0], 1, 'array key set');

--- a/test/issues/issue-express.js
+++ b/test/issues/issue-express.js
@@ -1,9 +1,0 @@
-function fn () {
-}
-
-// mixin Router class functions
-fn.__proto__ = {
-	use: 'hello'
-}
-
-console.log(fn.use);

--- a/test/issues/issue-runtime-107.js
+++ b/test/issues/issue-runtime-107.js
@@ -1,9 +1,6 @@
-/* TAP rig */
-function tap (max) { tap.t = 1; console.log(tap.t + '..' + max); };
-function ok (a, d) { console.log((a ? '' : 'not ') + 'ok', tap.t++, '-', d); }
-function eq (a, b, c) { ok(a == b, String(c) + ': ' + JSON.stringify(a) + ' == ' + JSON.stringify(b)); }
+var tap = require('../tap')
 
-tap(2);
+tap.count(1)
 
-eq('Hello World'.replace(/\s|l*/g, ''), 'HeoWord', '/\s|l*/ replace');
-eq('Hello World'.replace(/l*/g, '_'), '_H_e__o_ _W_o_r__d_', '/l*/ replace');
+tap.eq('Hello World'.replace(/\s|l*/g, ''), 'HeoWord', '/\s|l*/ replace');
+tap.eq('Hello World'.replace(/l*/g, '_'), '_H_e__o_ _W_o_r__d_', '/l*/ replace');

--- a/test/issues/issue-runtime-109.js
+++ b/test/issues/issue-runtime-109.js
@@ -1,9 +1,6 @@
-/* TAP rig */
-function tap (max) { tap.t = 1; console.log(tap.t + '..' + max); };
-function ok (a, d) { console.log((a ? '' : 'not ') + 'ok', tap.t++, '-', d); }
-function eq (a, b, c) { ok(a == b, String(c) + ': ' + String(a) + ' == ' + String(b)); }
+var tap = require('../tap')
 
-tap(2);
+tap.count(2)
 
-eq(JSON.stringify('a,b,c,d'.split(/,/)), JSON.stringify(['a', 'b', 'c', 'd']), 'split(/,/)');
-eq(JSON.stringify('a\r\nb\r\nc\r\nd'.split(/[\r\n]+/)), JSON.stringify(['a', 'b', 'c', 'd']), 'split(/[\\r\\n]+/)');
+tap.eq(JSON.stringify('a,b,c,d'.split(/,/)), JSON.stringify(['a', 'b', 'c', 'd']), 'split(/,/)');
+tap.eq(JSON.stringify('a\r\nb\r\nc\r\nd'.split(/[\r\n]+/)), JSON.stringify(['a', 'b', 'c', 'd']), 'split(/[\\r\\n]+/)');

--- a/test/issues/issue-runtime-117.js
+++ b/test/issues/issue-runtime-117.js
@@ -1,8 +1,5 @@
-/* TAP rig */
-function tap (max) { tap.t = 1; console.log(tap.t + '..' + max); };
-function ok (a, d) { console.log((a ? '' : 'not ') + 'ok', tap.t++, '-', d); }
-function eq (a, b, c) { ok(a == b, String(c) + ': ' + String(a) + ' == ' + String(b)); }
+var tap = require('../tap')
 
-tap(1);
+tap.count(1)
 
-eq('   text / x-lua  lua  !'.replace(/^\s*/g, ''), 'text / x-lua  lua  !', '/^\s*/ replaces only at BOL');
+tap.eq('   text / x-lua  lua  !'.replace(/^\s*/g, ''), 'text / x-lua  lua  !', '/^\s*/ replaces only at BOL');

--- a/test/issues/issue-runtime-122.js
+++ b/test/issues/issue-runtime-122.js
@@ -1,8 +1,5 @@
-/* TAP rig */
-function tap (max) { tap.t = 1; console.log(tap.t + '..' + max); };
-function ok (a, d) { console.log((a ? '' : 'not ') + 'ok', tap.t++, '-', d); }
-function eq (a, b, c) { ok(a == b, String(c) + ': ' + JSON.stringify(a) + ' == ' + JSON.stringify(b)); }
+var tap = require('../tap')
 
-tap(1);
+tap.count(1)
 
-eq('text / x-lua  lua  !'.replace(/^\s*/g, ''), 'text / x-lua  lua  !', '/^\s*/ does not replace non-BOL');
+tap.eq('text / x-lua  lua  !'.replace(/^\s*/g, ''), 'text / x-lua  lua  !', '/^\s*/ does not replace non-BOL');

--- a/test/issues/issue-runtime-133.js
+++ b/test/issues/issue-runtime-133.js
@@ -1,6 +1,10 @@
+var tap = require('../tap')
+
+tap.count(1)
+
 var Readable = require('stream').Readable;
 var rs = new Readable;
 rs._read = function () { }
 rs.pipe(process.stdout);
-rs.push('1..1\n')
-rs.push('ok\n');
+
+tap.ok(true);

--- a/test/issues/issue-runtime-146.js
+++ b/test/issues/issue-runtime-146.js
@@ -1,6 +1,9 @@
-console.log('1..2');
+var tap = require('../tap')
+
+tap.count(2)
+
 var a = [];
-console.log(a.length == 0 ? 'ok' : 'not ok');
+tap.eq(a.length, 0);
 a.sort(function(a, b) {return a.foo - b.foo});
 console.log('#', a);
-console.log(a.length == 0 ? 'ok' : 'not ok');
+tap.eq(a.length, 0);

--- a/test/issues/issue-runtime-150.js
+++ b/test/issues/issue-runtime-150.js
@@ -1,5 +1,7 @@
-console.log('1..3')
+var tap = require('../tap')
+
+tap.count(3)
 console.log('#', JSON.stringify("/".slice(0, -1)))
-console.log("/".slice(0, -1) == '' ? 'ok' : 'not ok')
-console.log("12345".slice(0, -3) == '12' ? 'ok' : 'not ok')
-console.log("12345".slice(0, -100) == '' ? 'ok' : 'not ok')
+tap.eq("/".slice(0, -1), '');
+tap.eq("12345".slice(0, -3), '12');
+tap.eq("12345".slice(0, -100), '');

--- a/test/issues/issue-runtime-156.js
+++ b/test/issues/issue-runtime-156.js
@@ -1,10 +1,13 @@
+var tap = require('../tap')
+
+tap.count(4)
+
 var querystring = require('querystring');
 var util = require('util');
 
-console.log('1..4');
 console.log('#', isFinite(5))
-console.log(isFinite(5) == true ? 'ok' : 'not ok');
+tap.eq(isFinite(5), true);
 console.log('#', querystring.stringify({room_id: 5}))
-console.log(querystring.stringify({room_id: 5}) == 'room_id=5' ? 'ok' : 'not ok')
-console.log(isFinite("0") == true ? 'ok' : 'not ok');
-console.log(isFinite("hi") == false ? 'ok' : 'not ok');
+tap.eq(querystring.stringify({room_id: 5}), 'room_id=5');
+tap.eq(isFinite("0"), true);
+tap.eq(isFinite("hi"), false);

--- a/test/issues/issue-runtime-158.js
+++ b/test/issues/issue-runtime-158.js
@@ -1,8 +1,11 @@
-console.log('1..7');
-console.log(Number.isFinite('5') == false ? 'ok' : 'not ok');
-console.log(Number.isFinite(NaN) == false ? 'ok' : 'not ok');
-console.log(Number.isFinite(Infinity) == false ? 'ok' : 'not ok');
-console.log(Number.isFinite(-Infinity) == false ? 'ok' : 'not ok');
-console.log(Number.isFinite(1.7976931348623157E+10308) == false ? 'ok' : 'not ok');
-console.log(Number.isFinite(1.7976931348623157E+10308 - 1) == true ? 'ok' : 'not ok');
-console.log(Number.isFinite(5) == true ? 'ok' : 'not ok');
+var tap = require('../tap')
+
+tap.count(7)
+
+tap.eq(Number.isFinite('5'), false);
+tap.eq(Number.isFinite(NaN), false);
+tap.eq(Number.isFinite(Infinity), false);
+tap.eq(Number.isFinite(-Infinity), false);
+tap.eq(Number.isFinite(1.7976931348623157E+10308), false);
+tap.eq(Number.isFinite(1.7976931348623157E+10308 - 1), true);
+tap.eq(Number.isFinite(5), true);

--- a/test/issues/issue-runtime-159.js
+++ b/test/issues/issue-runtime-159.js
@@ -1,6 +1,8 @@
-console.log('1..1');
+var tap = require('../tap')
+
+tap.count(1)
 
 var mAccelLast;
 var delta = 20 - mAccelLast; // Tessel would hang here!
 
-console.log('ok');
+tap.ok(true);

--- a/test/issues/issue-runtime-170.js
+++ b/test/issues/issue-runtime-170.js
@@ -1,5 +1,8 @@
-console.log('1..2');
+var tap = require('../tap')
+
+tap.count(2)
+
 var dash = require(__dirname + '/170/runtime-170/test-subfolder/subfolder');
-console.log(dash == true ? 'ok' : 'not ok');
+tap.eq(dash, true);
 var underscore = require(__dirname + '/170/runtime_170/test-subfolder/subfolder');
-console.log(underscore == true ? 'ok' : 'not ok');
+tap.eq(underscore, true);

--- a/test/issues/issue-runtime-173.js
+++ b/test/issues/issue-runtime-173.js
@@ -1,6 +1,8 @@
-console.log('1..1');
+var tap = require('../tap')
+
+tap.count(1)
 
 var c = 0xedb88320 ^ 62317068;
 console.log('#', c);
-console.log(c < 0 ? 'ok' : 'not ok');
+tap.ok(c < 0);
 

--- a/test/issues/issue-runtime-177.js
+++ b/test/issues/issue-runtime-177.js
@@ -1,4 +1,8 @@
-console.log('1..1');
+// Tests that NaN / Inf keys don't trigger errors.
+
+var tap = require('../tap')
+
+tap.count(1)
 
 var a = {}
 a.NaN = 0/0
@@ -10,4 +14,4 @@ a.infinity = 0/0
 a['-Infinity'] = 0/0
 a['-infinity'] = 0/0
 
-console.log('ok');
+tap.ok(true);

--- a/test/issues/issue-runtime-185.js
+++ b/test/issues/issue-runtime-185.js
@@ -1,10 +1,12 @@
-console.log('1..7');
+var tap = require('../tap')
 
-console.log("canal".lastIndexOf("a") == 3 ? 'ok': 'not ok')
-console.log("canal".lastIndexOf("a", 2) == 1 ? 'ok': 'not ok')
-console.log("canal".lastIndexOf("l", 4) == 4 ? 'ok': 'not ok')
-console.log("canal".lastIndexOf("a", 0) == -1 ? 'ok': 'not ok')
-console.log("canal".lastIndexOf("a", 8) == -1 ? 'ok': 'not ok')
-console.log("canal".lastIndexOf("a", -5) == -1 ? 'ok': 'not ok')
-console.log("canal".lastIndexOf("x") == -1 ? 'ok': 'not ok')
+tap.count(7)
+
+tap.eq("canal".lastIndexOf("a"), 3);
+tap.eq("canal".lastIndexOf("a", 2), 1)
+tap.eq("canal".lastIndexOf("l", 4), 4)
+tap.eq("canal".lastIndexOf("a", 0), -1)
+tap.eq("canal".lastIndexOf("a", 8), -1)
+tap.eq("canal".lastIndexOf("a", -5), -1)
+tap.eq("canal".lastIndexOf("x"), -1)
 

--- a/test/issues/issue-runtime-186.js
+++ b/test/issues/issue-runtime-186.js
@@ -1,10 +1,12 @@
-console.log('1..8');
+var tap = require('../tap')
 
-console.log("Blue Whale".indexOf("Blue") == 0 ? 'ok' : 'not ok');
-console.log("Blue Whale".indexOf("Whale") == 5 ? 'ok' : 'not ok');
-console.log("Blue Whale".indexOf("Blute") == -1 ? 'ok' : 'not ok');
-console.log("Blue Whale".indexOf("Whale", 0) == 5 ? 'ok' : 'not ok');
-console.log("Blue Whale".indexOf("Whale", 5) == 5 ? 'ok' : 'not ok');
-console.log("Blue Whale".indexOf("", 9) == 9 ? 'ok' : 'not ok');
-console.log("Blue Whale".indexOf("", 10) == 10 ? 'ok' : 'not ok');
-console.log("Blue Whale".indexOf("", 11) == 10 ? 'ok' : 'not ok');
+tap.count(8)
+
+tap.eq("Blue Whale".indexOf("Blue"), 0);
+tap.eq("Blue Whale".indexOf("Whale"), 5);
+tap.eq("Blue Whale".indexOf("Blute"), -1);
+tap.eq("Blue Whale".indexOf("Whale", 0), 5);
+tap.eq("Blue Whale".indexOf("Whale", 5), 5);
+tap.eq("Blue Whale".indexOf("", 9), 9);
+tap.eq("Blue Whale".indexOf("", 10), 10);
+tap.eq("Blue Whale".indexOf("", 11), 10);

--- a/test/issues/issue-runtime-199.js
+++ b/test/issues/issue-runtime-199.js
@@ -1,8 +1,5 @@
-/* TAP rig */
-function tap (max) { tap.t = 1; console.log(tap.t + '..' + max); };
-function ok (a, d) { console.log((a ? '' : 'not ') + 'ok', tap.t++, '-', d); }
-function eq (a, b, c) { ok(a == b, String(c) + ': ' + JSON.stringify(String(a)) + ' == ' + JSON.stringify(String(b))); }
+var tap = require('../tap')
 
-tap(1);
+tap.count(1)
 
-eq([0, 1].join(','), '0,1', '[0,1].join() does not omit 0');
+tap.eq([0, 1].join(','), '0,1', '[0,1].join() does not omit 0');

--- a/test/issues/issue-runtime-204.js
+++ b/test/issues/issue-runtime-204.js
@@ -1,11 +1,8 @@
-/* TAP rig */
-function tap (max) { tap.t = 1; console.log(tap.t + '..' + max); };
-function ok (a, d) { console.log((a ? '' : 'not ') + 'ok', tap.t++, '-', d); }
-function eq (a, b, c) { ok(a == b, String(c) + ': ' + JSON.stringify(String(a)) + ' == ' + JSON.stringify(String(b))); }
+var tap = require('../tap')
 
-tap(3);
+tap.count(3)
 
-eq(String([1]), '1', 'stringed-array doesn\'t leave trailing comma');
+tap.eq(String([1]), '1', 'stringed-array doesn\'t leave trailing comma');
 
-eq("12345678".match(/\d/g).length, [1,2,3,4,5,6,7,8].length, 'match split length');
-eq(String("12345678".match(/\d/g)), '1,2,3,4,5,6,7,8', 'match split entries');
+tap.eq("12345678".match(/\d/g).length, [1,2,3,4,5,6,7,8].length, 'match split length');
+tap.eq(String("12345678".match(/\d/g)), '1,2,3,4,5,6,7,8', 'match split entries');

--- a/test/issues/issue-runtime-269.js
+++ b/test/issues/issue-runtime-269.js
@@ -1,3 +1,7 @@
+var tap = require('../tap')
+
+tap.count(1)
+
 var o = { foo: 1 };
 var descriptor = Object.getOwnPropertyDescriptor(o, 'foo');
 var fields = [ 'writable', 'enumerable', 'configurable' ];
@@ -8,4 +12,4 @@ for (var i = 0; i < fields.length; i++) {
     break;
   }
 }
-console.log(result ? 'ok' : 'not ok');
+tap.ok(result);

--- a/test/issues/issue-runtime-276.js
+++ b/test/issues/issue-runtime-276.js
@@ -1,10 +1,10 @@
-/* test rig */ var t = 1, tmax = 1;
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
+var tap = require('../tap')
+
+tap.count(1)
 
 try {
   require("MISSING");
 } catch (e) {
     var msg = e.toString();
-    ok(msg.match(/find module .MISSING/), "no unexpected path in module resolution error");
+    tap.ok(msg.match(/find module .MISSING/), "no unexpected path in module resolution error");
 }

--- a/test/issues/issue-runtime-282.js
+++ b/test/issues/issue-runtime-282.js
@@ -1,3 +1,7 @@
+var tap = require('../tap')
+
+tap.count(1)
+
 var a = [1];
 var s = new Array(1);
 var o = {};
@@ -104,7 +108,4 @@ var count = 0;
 });
 result += count;
 
-console.log('1..1');
-console.log( result === 8 ? 'ok' : 'not ok' );
-
-
+tap.eq(result, 8);

--- a/test/issues/issue-runtime-283.js
+++ b/test/issues/issue-runtime-283.js
@@ -1,3 +1,7 @@
+var tap = require('../tap')
+
+tap.count(3)
+
 var a = [1];
 var o = {};
 var g = global || this;
@@ -119,10 +123,9 @@ a.filter(function(value, index, object) {
   }
 });
 
-console.log('1..3');
 // This will pass when forEach thisArg is implemented
 // and default this is corrected. The value of `result`
 // is currently 18.
-console.log(result === 20 ? 'ok' : 'not ok');
-console.log(mapped[0] === 1 ? 'ok' : 'not ok');
-console.log(filtered[0] === 1 ? 'ok' : 'not ok');
+tap.eq(result, 20);
+tap.eq(mapped[0], 1);
+tap.eq(filtered[0], 1);

--- a/test/issues/issue-runtime-287.js
+++ b/test/issues/issue-runtime-287.js
@@ -1,49 +1,51 @@
-console.log('1..15');
+var tap = require('../tap')
+
+tap.count(15)
 
 var arr = [1, 2, 3, 1, 2, 3];
 
 console.log('#', arr.indexOf(2));
-console.log(arr.indexOf(2) == 1 ? 'ok' : 'not ok');
+tap.eq(arr.indexOf(2), 1);
 
 console.log('#', arr.indexOf(2, 0));
-console.log(arr.indexOf(2, 0) == 1 ? 'ok' : 'not ok');
+tap.eq(arr.indexOf(2, 0), 1);
 
 console.log('#', arr.indexOf(2, 1));
-console.log(arr.indexOf(2, 1) == 1 ? 'ok' : 'not ok');
+tap.eq(arr.indexOf(2, 1), 1);
 
 console.log('#', arr.indexOf(2, 2));
-console.log(arr.indexOf(2, 2) == 4 ? 'ok' : 'not ok');
+tap.eq(arr.indexOf(2, 2), 4);
 
 console.log('#', arr.indexOf(2, 4));
-console.log(arr.indexOf(2, 4) == 4 ? 'ok' : 'not ok');
+tap.eq(arr.indexOf(2, 4), 4);
 
 console.log('#', arr.indexOf(2, 5));
-console.log(arr.indexOf(2, 5) == -1 ? 'ok' : 'not ok');
+tap.eq(arr.indexOf(2, 5), -1);
 
 console.log('#', arr.indexOf(3, 5));
-console.log(arr.indexOf(3, 5) == 5 ? 'ok' : 'not ok');
+tap.eq(arr.indexOf(3, 5), 5);
 
 console.log('#', arr.indexOf(3, 6));
-console.log(arr.indexOf(3, 6) == -1 ? 'ok' : 'not ok');
+tap.eq(arr.indexOf(3, 6), -1);
 
 console.log('#', arr.indexOf(2, 10));
-console.log(arr.indexOf(2, 10) == -1 ? 'ok' : 'not ok');
+tap.eq(arr.indexOf(2, 10), -1);
 
 console.log('#', arr.indexOf(2, -1));
-console.log(arr.indexOf(2, -1) == -1 ? 'ok' : 'not ok');
+tap.eq(arr.indexOf(2, -1), -1);
 
 console.log('#', arr.indexOf(2, -2));
-console.log(arr.indexOf(2, -2) == 4 ? 'ok' : 'not ok');
+tap.eq(arr.indexOf(2, -2), 4);
 
 console.log('#', arr.indexOf(2, -2));
-console.log(arr.indexOf(2, -2) == 4 ? 'ok' : 'not ok');
+tap.eq(arr.indexOf(2, -2), 4);
 
 console.log('#', arr.indexOf(2, -4));
-console.log(arr.indexOf(2, -4) == 4 ? 'ok' : 'not ok');
+tap.eq(arr.indexOf(2, -4), 4);
 
 console.log('#', arr.indexOf(2, -5));
-console.log(arr.indexOf(2, -5) == 1 ? 'ok' : 'not ok');
+tap.eq(arr.indexOf(2, -5), 1);
 
 console.log('#', arr.indexOf(2, -10));
-console.log(arr.indexOf(2, -10) == 1 ? 'ok' : 'not ok');
+tap.eq(arr.indexOf(2, -10), 1);
 

--- a/test/issues/issue-runtime-292.js
+++ b/test/issues/issue-runtime-292.js
@@ -1,4 +1,8 @@
+var tap = require('../tap')
+
+tap.count(1)
+
 var str = "x".replace(/x/, function () {
   return true;
 });
-console.log(JSON.stringify(str));
+tap.eq(str, 'true');

--- a/test/issues/issue-runtime-295.js
+++ b/test/issues/issue-runtime-295.js
@@ -1,6 +1,6 @@
 var tap = require('../tap');
 
-tap(3);
+tap.count(3);
 
 tap.ok(RegExp.prototype.hasOwnProperty('toString'), 'regex has own property toString');
 tap.eq(/abc/g.toString(), '/abc/g', 'tostring method on regex');

--- a/test/issues/issue-runtime-296.js
+++ b/test/issues/issue-runtime-296.js
@@ -1,6 +1,6 @@
 var tap = require('../tap');
 
-tap(3)
+tap.count(3)
 
 var d = new Date(42);
 tap.eq(d.valueOf(), 42, 'valueOf');

--- a/test/issues/issue-runtime-298.js
+++ b/test/issues/issue-runtime-298.js
@@ -1,13 +1,15 @@
-console.log('1..4');
+var tap = require('../tap')
+
+tap.count(4)
 
 console.log('#', parseFloat("x"));
-console.log(isNaN(parseFloat("x")) ? 'ok' : 'not ok');
+tap.ok(isNaN(parseFloat("x")))
 
 console.log('#', parseInt("x"));
-console.log(isNaN(parseInt("x")) ? 'ok' : 'not ok');
+tap.ok(isNaN(parseInt("x")))
 
 console.log('#', Number("x"));
-console.log(isNaN(Number("x")) ? 'ok' : 'not ok');
+tap.ok(isNaN(Number("x")))
 
 console.log('#', +"x");
-console.log(isNaN(+"x") ? 'ok' : 'not ok');
+tap.ok(isNaN(+"x"))

--- a/test/issues/issue-runtime-302.js
+++ b/test/issues/issue-runtime-302.js
@@ -15,7 +15,7 @@ var tests = [
   [(function () { return arguments; })(), 'Arguments', 'object']
 ];
 
-tap(tests.length * 2);
+tap.count(tests.length * 2);
 
 tests.forEach(function (d) {
   console.log('#', d[0])

--- a/test/issues/issue-runtime-303.js
+++ b/test/issues/issue-runtime-303.js
@@ -1,23 +1,25 @@
 // A JS error should be thrown on invalid Objects.
 
-console.log('1..9');
+var tap = require('../tap')
+
+tap.count(9)
 
 function test (source, isobject) {
   console.log('');
   try {
     Object.keys(source);
     if (isobject) {
-      console.log('ok - no error on object')
+      tap.ok(true, 'no error on object')
     } else {
-      console.log('not ok - error not generated for non-object');
+      tap.ok(false, 'error not generated for non-object');
     }
   } catch (e) {
     if (isobject) {
-      console.log('not ok - error generated on object');
-      console.log('not ok - error generated on object');
+      tap.ok(false, 'error generated on object');
+      tap.ok(false, 'error generated on object');
     } else {
-      console.log(e instanceof Error ? 'ok' : 'not ok');
-      console.log(e instanceof TypeError ? 'ok' : 'not ok');
+      tap.ok(e instanceof Error);
+      tap.ok(e instanceof TypeError);
       console.log('#', e.message)
     }
   }

--- a/test/issues/issue-runtime-304.js
+++ b/test/issues/issue-runtime-304.js
@@ -1,6 +1,8 @@
 // Tests throw/catch/finally blocks with return statements.
 
-console.log('1..3');
+var tap = require('../tap');
+
+tap.count(3);
 
 function test (dothrow) {
   var a = [];
@@ -28,8 +30,8 @@ function test (dothrow) {
   return a.join(' ');
 }
 
-console.log(test(false) == 'try finally -> try' ? 'ok' : 'not ok')
-console.log(test(true) == 'try catch finally -> catch' ? 'ok' : 'not ok')
+tap.eq(test(false), 'try finally -> try');
+tap.eq(test(true), 'try catch finally -> catch');
 
 // This is an edge case for colony-compiler where try{} and catch{}
 // blocks are actually evaluated closures. Before 0.6.16, try blocks can
@@ -39,9 +41,9 @@ var ret = (function () {
   try {
     return null
   } catch (e) { }
-  console.log('not ok');
+  tap.ok(false);
   return true;
 })();
 if (ret == null) {
-  console.log('ok');
+  tap.ok(true);
 }

--- a/test/issues/issue-runtime-305.js
+++ b/test/issues/issue-runtime-305.js
@@ -1,5 +1,5 @@
 var tap = require('../tap')
 
-tap(1)
+tap.count(1)
 
 tap.eq(global._G && global._G._HSMATCH, null, '_HSMATCH object should not be accessible');

--- a/test/issues/issue-runtime-306.js
+++ b/test/issues/issue-runtime-306.js
@@ -1,24 +1,21 @@
-/* TAP rig */
-function tap (max) { tap.t = 1; console.log(tap.t + '..' + max); };
-function ok (a, d) { console.log((a ? '' : 'not ') + 'ok', tap.t++, '-', d); }
-function eq (a, b, c) { ok(a == b, String(c) + ': ' + JSON.stringify(String(a)) + ' == ' + JSON.stringify(String(b))); }
+var tap = require('../tap');
 
-tap(11);
+tap.count(11);
 
-ok((new Buffer([-1]))[0] == 0xff, 'wrap: -1 == 0xff');
-ok((new Buffer([0x555 % 0xFF]))[0] == 0x5a, 'wrap: 0x555 % 0xFF == 0x5a');
+tap.ok((new Buffer([-1]))[0] == 0xff, 'wrap: -1 == 0xff');
+tap.ok((new Buffer([0x555 % 0xFF]))[0] == 0x5a, 'wrap: 0x555 % 0xFF == 0x5a');
 
-ok((new Buffer([256]))[0] == 0x00, 'wrap: 256 == 0');
-ok((new Buffer([-256]))[0] == 0x00, 'wrap: -256 == 0');
-ok((new Buffer([0x555]))[0] == 0x55, 'wrap: 0x555 == 0x55');
-ok((new Buffer([300]))[0] == 0x2c, 'wrap: 300 == 0x2c');
-ok((new Buffer([-300]))[0] == 0xd4, 'wrap: -300 == 0xd4');
-ok((new Buffer([-0x555]))[0] == 0xab, 'wrap: -0x555 == 0xab');
+tap.ok((new Buffer([256]))[0] == 0x00, 'wrap: 256 == 0');
+tap.ok((new Buffer([-256]))[0] == 0x00, 'wrap: -256 == 0');
+tap.ok((new Buffer([0x555]))[0] == 0x55, 'wrap: 0x555 == 0x55');
+tap.ok((new Buffer([300]))[0] == 0x2c, 'wrap: 300 == 0x2c');
+tap.ok((new Buffer([-300]))[0] == 0xd4, 'wrap: -300 == 0xd4');
+tap.ok((new Buffer([-0x555]))[0] == 0xab, 'wrap: -0x555 == 0xab');
 
 var a = 0x555, b = 0xFF
-ok((-a) % b == -90, 'modulus check: -0x555 % 0xFF == -90');
-ok((new Buffer([(-0x555) % 0xff]))[0] == 0xa6, 'wrap: -0x555 % 0xff == 0xa6');
+tap.ok((-a) % b == -90, 'modulus check: -0x555 % 0xFF == -90');
+tap.ok((new Buffer([(-0x555) % 0xff]))[0] == 0xa6, 'wrap: -0x555 % 0xff == 0xa6');
 
 var b = new Buffer(1);
 b.writeInt8(-1, 0);
-ok(b[0] == 0xff, 'writing -1 yields 0');
+tap.ok(b[0] == 0xff, 'writing -1 yields 0');

--- a/test/issues/issue-runtime-307.js
+++ b/test/issues/issue-runtime-307.js
@@ -1,13 +1,15 @@
-console.log('1..4')
+var tap = require('../tap');
+
+tap.count(4);
 
 var test = /^(?::(\d*))?/
 var a = ('WRONG'.match(test))
 
-console.log(a[0] == "" ? 'ok' : 'not ok');
-console.log(a[1] == undefined ? 'ok' : 'not ok');
+tap.eq(a[0], "");
+tap.eq(a[1], undefined);
 
 var test = /^(?::(\d*))?/
 var a = (':5'.match(test))
 
-console.log(a[0] == ":5" ? 'ok' : 'not ok');
-console.log(a[1] == "5" ? 'ok' : 'not ok');
+tap.eq(a[0], ":5")
+tap.eq(a[1], "5");

--- a/test/issues/issue-runtime-314.js
+++ b/test/issues/issue-runtime-314.js
@@ -1,3 +1,7 @@
+var tap = require('../tap');
+
+tap.count(1);
+
 var result = 0;
 
 if (NaN) {
@@ -5,5 +9,4 @@ if (NaN) {
   result++;
 }
 
-console.log('1..1');
-console.log(!result ? 'ok' : 'not ok');
+tap.ok(!result, 'NaN should be a falsy value in if () {} block.');

--- a/test/issues/issue-runtime-320.js
+++ b/test/issues/issue-runtime-320.js
@@ -1,7 +1,10 @@
+var tap = require('../tap');
+
+tap.count(2);
+
 var buf = new Buffer('test');
 
-console.log('1..2');
 console.log('#', JSON.stringify(String.fromCharCode.apply(null, buf)));
-console.log(String.fromCharCode.apply(null, buf) == 'test' ? 'ok' : 'not ok')
+tap.eq(String.fromCharCode.apply(null, buf), 'test')
 console.log('#', JSON.stringify(String.fromCharCode.apply(null, [])));
-console.log(String.fromCharCode.apply(null, []) == '' ? 'ok' : 'not ok')
+tap.eq(String.fromCharCode.apply(null, []), '')

--- a/test/issues/issue-runtime-337.js
+++ b/test/issues/issue-runtime-337.js
@@ -1,4 +1,6 @@
-console.log('1..1');
+var tap = require('../tap');
+
+tap.count(1);
 
 var a = {
   test : function() { console.log('test');}
@@ -10,7 +12,7 @@ B.test = a.test;
 
 for (var prop in B) {
   if (prop == 'test') {
-  	console.log('ok');
+  	tap.ok(true, 'only function object prop should be "test"')
   } else {
   	throw new Error('Unexpected key.');
   }

--- a/test/issues/issue-runtime-345.js
+++ b/test/issues/issue-runtime-345.js
@@ -1,15 +1,17 @@
-console.log('1..2')
+var tap = require('../tap');
+
+tap.count(2);
 
 // Array.prototype.forEach applied to String
 var a = [];
 Array.prototype.forEach.call("foobar", function(ch) {
   a.push(ch);
 });
-console.log(a.join('') == 'foobar' ? 'ok' : 'not ok');
+tap.eq(a.join(''), 'foobar');
 
 // Array.prototype.forEach applied to array
 var a = [];
 Array.prototype.forEach.call("foobar".split(''), function(ch) {
   a.push(ch);
 });
-console.log(a.join('') == 'foobar' ? 'ok' : 'not ok');
+tap.eq(a.join(''), 'foobar');

--- a/test/issues/issue-runtime-360.js
+++ b/test/issues/issue-runtime-360.js
@@ -1,11 +1,13 @@
-console.log('1..6');
+var tap = require('../tap');
+
+tap.count(3)
 
 var a = [1,2,3];
 
 Object.keys(a).forEach(function (key) {
-	console.log(typeof key == 'string' ? 'ok' : 'not ok - Object.keys returns non-string', key, typeof key);
+	tap.eq(typeof key, 'string', 'Object.keys returns non-string');
 })
 
 for (var key in a) {
-	console.log(typeof key == 'string' ? 'ok' : 'not ok - Object.keys returns non-string', key, typeof key);	
+	tap.eq(typeof key, 'string', 'Object.keys returns non-string');
 }

--- a/test/issues/issue-runtime-362.js
+++ b/test/issues/issue-runtime-362.js
@@ -1,5 +1,5 @@
 var tap = require('../tap');
 
-tap(1)
+tap.count(1)
 
 tap.eq(['a','b',{}].join('/'), 'a/b/[object Object]', 'object in array passes Array.prototype.join');

--- a/test/issues/issue-runtime-368.js
+++ b/test/issues/issue-runtime-368.js
@@ -1,9 +1,11 @@
-console.log('1..2');
+var tap = require('../tap');
+
+tap.count(2)
 
 var obj = [ ];
 function test (k) {
-	console.log(typeof k == 'string' ? 'ok' : 'not ok', typeof k)
+	tap.eq(typeof k, 'string', typeof k)
 	var b = obj[k]
-	console.log(typeof k == 'string' ? 'ok' : 'not ok', typeof k)
+	tap.eq(typeof k, 'string', typeof k)
 }
 test('5')

--- a/test/issues/issue-runtime-385.js
+++ b/test/issues/issue-runtime-385.js
@@ -1,6 +1,6 @@
 var tap = require('../tap');
 
-tap(2);
+tap.count(2);
 
 var a = Date.now();
 var b = new Date(a);

--- a/test/issues/issue-runtime-419.js
+++ b/test/issues/issue-runtime-419.js
@@ -1,6 +1,6 @@
 var tap = require('../tap');
 
-tap(2);
+tap.count(2);
 
 var foo = 5;
 tap.eq(foo.hasOwnProperty('bar'), false);

--- a/test/net/dns.js
+++ b/test/net/dns.js
@@ -1,9 +1,11 @@
+var tap = require('../tap');
+
+tap.count(2);
+
 var dns = require('dns');
 
-console.log('1..2')
-
 dns.resolve('graph.facebook.com', function (err, ip) {
-	console.log(!err ? 'ok' : 'not ok', 1);
-	console.log(ip == null || Array.isArray(ip) ? 'ok' : 'not ok', 2);
+	tap.ok(!err);
+	tap.ok(ip == null || Array.isArray(ip));
 	console.log('#', ip);
 })

--- a/test/net/http-get-query.js
+++ b/test/net/http-get-query.js
@@ -1,13 +1,12 @@
-console.log('1..1');
+var tap = require('../tap');
+
+tap.count(1);
+
 var http = require('http');
 
 http.get("http://api.openweathermap.org/data/2.5/weather?id=5327684&units=imperial", function(res) {
   console.log('#', res.statusCode)
-  if (res.statusCode == 200) {
-    console.log('ok');
-  } else {
-    console.log('not ok');
-  }
-}).on('error', function(e) {
-  console.log('not ok -', e);
+  tap.eq(res.statusCode, 200, 'status code');
+}).on('error', function (e) {
+  tap.ok(false, String(e));
 });

--- a/test/net/http-get.js
+++ b/test/net/http-get.js
@@ -1,18 +1,14 @@
-console.log('1..1')
+var tap = require('../tap');
+
+tap.count(1);
 
 var http = require('http');
 
-// Temporary tessel catchall
-try {
-	http.get("http://www.google.com/index.html", function (res) {
-	  console.log('ok')
-	  console.log('# statusCode', res.statusCode)
-	  res.on('data', function (data) {
-	  	console.log('# received', data.length, 'bytes');
-	  })
-	}).on('error', function (e) {
-	  console.log('not ok -', e.message, 'error event #SKIP')
-	});
-} catch (e) {
-	console.log('not ok -', e.message, 'error thrown #SKIP')
-}
+http.get("http://www.google.com/index.html", function (res) {
+  tap.ok(typeof res.statusCode, 'number');
+  res.on('data', function (data) {
+    console.log('# received', data.length, 'bytes');
+  })
+}).on('error', function (e) {
+  tap.ok(false, String(e));
+});

--- a/test/net/http-md5.js
+++ b/test/net/http-md5.js
@@ -1,17 +1,20 @@
 // TLS module
 if (!require('crypto')._tls) {
-  console.log('1..1');
-  console.log('not ok - crypto not enabled #SKIP');
+  var tap = require('../tap');
+  tap.count(1);
+  tap.ok(false, 'crypto not enabled #SKIP');
   process.exit(0);
 }
 
-console.log('1..2')
+var tap = require('../tap');
+
+tap.count(2);
 
 var http = require('http');
 var crypto = require('crypto');
 
 http.get("http://httpstat.us/200", function (res) {
-  console.log('ok')
+  tap.eq(typeof res.statusCode, 'number');
   console.log('# statusCode', res.statusCode)
 
   var hash = crypto.createHash('md5');
@@ -20,8 +23,8 @@ http.get("http://httpstat.us/200", function (res) {
   hash.on('readable', function () {
   	var md5 = hash.read().toString('hex');
   	console.log('#', md5);
-  	console.log(md5 == '3c3f2943d4337318cf737f45d5b564cd' ? 'ok' : 'not ok');
+  	tap.eq(md5, '3c3f2943d4337318cf737f45d5b564cd');
   })
 }).on('error', function (e) {
-  console.log('not ok -', e.message, 'error event')
+  tap.ok(false, String(e));
 });

--- a/test/net/http-req-ip.js
+++ b/test/net/http-req-ip.js
@@ -1,25 +1,23 @@
-console.log('1..1')
+var tap = require('../tap');
+
+tap.count(1);
 
 var http = require('http');
 
 // Temporary tessel catchall
 
 // This is a hardcoded IP for google.com.
-try {
-	http.request({
-		hostname: '64.233.167.99',
-		port: 80,
-		path: '/index.html',
-		method: 'GET'
-	}, function (res) {
-	  console.log('ok')
-	  console.log('# statusCode', res.statusCode)
-	  res.on('data', function (data) {
-	  	console.log('# received', data.length, 'bytes');
-	  })
-	}).on('error', function (e) {
-	  console.log('not ok -', e.message, '#SKIP')
-	});
-} catch (e) {
-	console.log('not ok -', e.message, '#SKIP')
-}
+http.request({
+	hostname: '64.233.167.99',
+	port: 80,
+	path: '/index.html',
+	method: 'GET'
+}, function (res) {
+  tap.eq(typeof res.statusCode, 'number');
+  console.log('# statusCode', res.statusCode)
+  res.on('data', function (data) {
+  	console.log('# received', data.length, 'bytes');
+  })
+}).on('error', function (e) {
+  tap.ok(false, String(e));
+});

--- a/test/suite/__proto__.js
+++ b/test/suite/__proto__.js
@@ -1,6 +1,22 @@
+var tap = require('../tap');
+
+tap.count(1);
+
 var animal = { eats: true }
 var rabbit = { jumps: true }
 
 rabbit.__proto__ = animal  // inherit
 
-console.log(rabbit.eats) // true
+tap.eq(rabbit.eats, true) // true
+
+/*
+// TODO
+function fn () {
+}
+
+fn.__proto__ = {
+	use: 'hello'
+}
+
+tap.eq(fn.use, 'hello');
+*/

--- a/test/suite/arguments.js
+++ b/test/suite/arguments.js
@@ -1,11 +1,13 @@
-console.log('1..2');
+var tap = require('../tap');
+
+tap.count(2);
 
 var a = function () {
 	var fake = Array.prototype.slice(arguments);
-	console.log(fake && fake.length == 0 ? 'ok' : 'not ok');
+	tap.eq(fake && fake.length, 0, '.slice with improper arguments does nothing.');
 
     var args = Array.prototype.slice.apply(arguments);
-    console.log(args && args.length == 3 ? 'ok' : 'not ok');
+    tap.eq(args && args.length, 3, '.slice with arguments as call object returns proper array.');
 }
 
 a(1, 2, 3);

--- a/test/suite/array.js
+++ b/test/suite/array.js
@@ -1,7 +1,6 @@
-/* test rig */ var t = 1, tmax = 44
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
+
+tap.count(46);
 
 function arreq (a, b) {
 	if (a.length != b.length) {
@@ -16,137 +15,137 @@ function arreq (a, b) {
 }
 
 var arr = [];
-ok(arr.length == 0, 'array::push - length')
+tap.ok(arr.length == 0, 'array::push - length')
 arr.push(1, 2, 3, 4, 5);
-ok(arr.length == 5, 'array::push - values added, accepts multiple args');
+tap.ok(arr.length == 5, 'array::push - values added, accepts multiple args');
 
 var arr = [1, 2, 3, 4, 5];
-ok(arr.length == 5, 'array::pop - length')
-ok(arr.pop() == 5, 'array::pop - values popped');
-ok(arr.length == 4, 'array::pop - length modified');
+tap.ok(arr.length == 5, 'array::pop - length')
+tap.ok(arr.pop() == 5, 'array::pop - values popped');
+tap.ok(arr.length == 4, 'array::pop - length modified');
 var arr = [];
-ok(arr.pop() == null, 'array::pop - null values popped');
-ok(arr.length == 0, 'array::pop - length unmodified when 0');
+tap.ok(arr.pop() == null, 'array::pop - null values popped');
+tap.ok(arr.length == 0, 'array::pop - length unmodified when 0');
 
 var a = [1];
 a.splice(0, 1);
-ok(arreq(a, []), 'splice(0, 1)');
+tap.ok(arreq(a, []), 'splice(0, 1)');
 
 var a = [1, 2, 3];
 a.splice(1, 1);
-ok(arreq(a, [1, 3]), 'splice(1, 1)');
+tap.ok(arreq(a, [1, 3]), 'splice(1, 1)');
 
 var a = [2, 3];
 a.unshift(1);
-ok(arreq(a, [1, 2, 3]), 'unshift(1)')
+tap.ok(arreq(a, [1, 2, 3]), 'unshift(1)')
 
 var arr = [2];
-ok(arr.length == 1, 'array::unshift - length')
+tap.ok(arr.length == 1, 'array::unshift - length')
 arr.unshift(1);
-ok(arreq(arr, [1, 2]), 'array::unshift - correct')
-ok(arr.length == 2, 'array::unshift - unshift redefines length')
+tap.ok(arreq(arr, [1, 2]), 'array::unshift - correct')
+tap.ok(arr.length == 2, 'array::unshift - unshift redefines length')
 
 var arr = ["adrian", "zankich"];
-ok(arr.length == 2, 'array::shift - length')
+tap.ok(arr.length == 2, 'array::shift - length')
 var first_name = arr.shift();
-ok(arr.length == 1, 'array::shift - shift redefines length');
-ok(first_name == 'adrian', 'array::shift - shifted value')
+tap.ok(arr.length == 1, 'array::shift - shift redefines length');
+tap.ok(first_name == 'adrian', 'array::shift - shifted value')
 var arr = [];
-ok(arr.shift() == null, 'array::shift - null values shifted');
-ok(arr.length == 0, 'array::shift - length unmodified when 0');
+tap.ok(arr.shift() == null, 'array::shift - null values shifted');
+tap.ok(arr.length == 0, 'array::shift - length unmodified when 0');
 
-ok([0, 0, 0, 0, 0, 0].length == 6);
-ok(arreq([0, 1, 2, 3, 4, 5].slice(0, 5), [0, 1, 2, 3, 4]))
-ok(arreq([0, 0, 0, 0, 0, 0].slice(0, 5), [0, 0, 0, 0, 0]));
-ok(arreq([0, 1, 2, 3, 4, 5].slice(1), [1, 2, 3, 4, 5]), 'slice(1) returns full array')
+tap.ok([0, 0, 0, 0, 0, 0].length == 6);
+tap.ok(arreq([0, 1, 2, 3, 4, 5].slice(0, 5), [0, 1, 2, 3, 4]))
+tap.ok(arreq([0, 0, 0, 0, 0, 0].slice(0, 5), [0, 0, 0, 0, 0]));
+tap.ok(arreq([0, 1, 2, 3, 4, 5].slice(1), [1, 2, 3, 4, 5]), 'slice(1) returns full array')
 
 
 var a = new Array(50);
 a[20] = 'b';
-ok(a.length == 50, 'new Array(50) length is 50')
+tap.ok(a.length == 50, 'new Array(50) length is 50')
 
 var b = [];
 b[20] = 'b';
-ok(b.length == 21, 'setting sparse high array index extends array');
+tap.ok(b.length == 21, 'setting sparse high array index extends array');
 
 var c = [1, 2, 3];
 c[3] = 4;
-ok(c.length == 4, 'setting non-sparse high array index extends array');
+tap.ok(c.length == 4, 'setting non-sparse high array index extends array');
 
 var a = [1,2,3];
 console.log("# array full:", a, a.length);
-ok(a.length == 3);
+tap.ok(a.length == 3);
 a[0] = undefined;
 a[1] = undefined;
 console.log("# array two undefined:", a, a.length);
-ok(a.length == 3);
+tap.ok(a.length == 3);
 a[2] = undefined;
 console.log("# array three undefined:", a, a.length);
-ok(a.length == 3);
+tap.ok(a.length == 3);
 
-ok([0, 1, 2, 3].reduce(function(a, b) {
+tap.ok([0, 1, 2, 3].reduce(function(a, b) {
     return a + b;
 }) == 6, 'array reduce');
 
-ok(arreq([[0, 1], [2, 3], [4, 5]].reduce(function(a, b) {
+tap.ok(arreq([[0, 1], [2, 3], [4, 5]].reduce(function(a, b) {
     return a.concat(b);
 }), [0, 1, 2, 3, 4, 5]), 'array reduce with init');
 
 var i = 1;
 var arr = [].concat(i);
-ok(arreq(arr, [i]), 'array concats values');
+tap.ok(arreq(arr, [i]), 'array concats values');
 console.log('#', arr)
 
 var i = 1;
 var arr = [].concat([5], i);
-ok(arreq(arr, [5, i]), 'array concats values and arrays');
+tap.ok(arreq(arr, [5, i]), 'array concats values and arrays');
 console.log('#', arr)
 
 var i = 1;
 var arr = [].concat([5], [6, 7]);
-ok(arreq(arr, [5, 6, 7]), 'array concats arrays');
+tap.ok(arreq(arr, [5, 6, 7]), 'array concats arrays');
 console.log('#', arr)
 
 var i = 1;
 var arr = [5].concat([6, 7], [8]);
-ok(arreq(arr, [5, 6, 7, 8]), 'array concats arrays');
+tap.ok(arreq(arr, [5, 6, 7, 8]), 'array concats arrays');
 console.log('#', arr)
 
 // Array::reverse
 var arr = [1, 2, 3];
 arr.reverse();
-ok(arreq(arr, [3, 2, 1]), 'array reverses in place');
-ok(arreq(arr.reverse(), [1, 2, 3]), 'array reverses');
-ok(arreq([0xFF, 0x00, 0x00, 0x80, 0x3f, 0xFF].reverse(), [0xFF, 0x3f, 0x80, 0x00, 0x00, 0xFF]), 'array reverses')
+tap.ok(arreq(arr, [3, 2, 1]), 'array reverses in place');
+tap.ok(arreq(arr.reverse(), [1, 2, 3]), 'array reverses');
+tap.ok(arreq([0xFF, 0x00, 0x00, 0x80, 0x3f, 0xFF].reverse(), [0xFF, 0x3f, 0x80, 0x00, 0x00, 0xFF]), 'array reverses')
 
 // Array::reduce
 var test = Buffer([5,4,3]);
-ok(Array.prototype.slice.call(test).join('') == '543', 'Array::join called on buffer works')
+tap.ok(Array.prototype.slice.call(test).join('') == '543', 'Array::join called on buffer works')
 sum = Array.prototype.reduce.call(test, function (sum, n) { return sum+n; }, 0);
-ok(sum == 12, 'Array::reduce called on non-array object succeeds');
+tap.ok(sum == 12, 'Array::reduce called on non-array object succeeds');
 
 // Array creation
 var a = Array(1,2,3)
-ok(arreq(a, [1,2,3]), 'Array(1,2,3) == [1,2,3]')
+tap.ok(arreq(a, [1,2,3]), 'Array(1,2,3) == [1,2,3]')
 
 // Array join
-ok([1,2,3].join(',') == '1,2,3');
-ok([1].join(',') == '1');
-ok([null, null, null].join(',') == ',,');
+tap.ok([1,2,3].join(',') == '1,2,3');
+tap.ok([1].join(',') == '1');
+tap.ok([null, null, null].join(',') == ',,');
 
 // Array.prototype.forEach applied to String
 var a = [];
 Array.prototype.forEach.call("foobar", function(ch) {
   a.push(ch);
 });
-console.log(a.join('') == 'foobar' ? 'ok' : 'not ok');
+tap.eq(a.join(''), 'foobar');
 
 // Array.prototype.forEach applied to array
 var a = [];
 Array.prototype.forEach.call("foobar".split(''), function(ch) {
   a.push(ch);
 });
-console.log(a.join('') == 'foobar' ? 'ok' : 'not ok');
+tap.eq(a.join(''), 'foobar');
 
 // // Array.prototype.forEach applied to sparse array.
 // var a = []; a[25] = 25;
@@ -156,4 +155,4 @@ console.log(a.join('') == 'foobar' ? 'ok' : 'not ok');
 //   	process.exit(1)
 //   }
 // });
-console.log('ok');
+tap.ok(true);

--- a/test/suite/bind.js
+++ b/test/suite/bind.js
@@ -1,7 +1,6 @@
-/* test rig */ var t = 1, tmax = 2
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
+
+tap.count(4);
 
 var util = require('util');
 var EventEmitter = require('events').EventEmitter;
@@ -17,11 +16,11 @@ function Test() {
 
 var i = 1;
 Test.prototype.parseIncoming = function(data, _, _, _, _, c) {
-    ok(data == i, 'test ' + i + ' bound arguments correctly');
+    tap.ok(data == i, 'test ' + i + ' bound arguments correctly');
     console.log('#', arguments)
     i++
     if (i == 4) {
-    	ok(c != null, 'last numerical value included');
+    	tap.ok(c != null, 'last numerical value included');
     }
 }
 

--- a/test/suite/bitmath.js
+++ b/test/suite/bitmath.js
@@ -1,41 +1,38 @@
-/* TAP rig */
-function tap (max) { tap.t = 1; console.log(tap.t + '..' + max); };
-function ok (a, d) { console.log((a ? '' : 'not ') + 'ok', tap.t++, '-', d); }
-function eq (a, b, c) { ok(a == b, String(c) + ': ' + String(a) + ' == ' + String(b)); }
+var tap = require('../tap');
 
-tap(27);
+tap.count(27);
 
-eq(0 ^ 10, 10, 'xor operator');
-eq('' ^ 10, 10, 'xor operator');
-eq(null ^ 10, 10, 'xor operator');
+tap.eq(0 ^ 10, 10, 'xor operator');
+tap.eq('' ^ 10, 10, 'xor operator');
+tap.eq(null ^ 10, 10, 'xor operator');
 
-eq(4 & 5, 4, 'and operator');
-eq(65535 & 0xFF, 0xFF, 'and operator');
-eq(0xff & 0, 0, 'and operator');
-eq(null & 5, 0, 'and operator');
-eq(null & '', 0, 'and operator');
+tap.eq(4 & 5, 4, 'and operator');
+tap.eq(65535 & 0xFF, 0xFF, 'and operator');
+tap.eq(0xff & 0, 0, 'and operator');
+tap.eq(null & 5, 0, 'and operator');
+tap.eq(null & '', 0, 'and operator');
 
-eq(1 | 0xFE, 0xFF, 'or operator');
-eq(null | 1, 1, 'or operator');
-eq('' | 1, 1, 'or operator');
+tap.eq(1 | 0xFE, 0xFF, 'or operator');
+tap.eq(null | 1, 1, 'or operator');
+tap.eq('' | 1, 1, 'or operator');
 
-eq(~0x7f, -128, 'not operator #SKIP');
-eq(~0xFF, -256, 'not operator #SKIP');
-eq(~0, -1, 'not operator #SKIP');
-eq(~(-0x80), 127, 'not operator #SKIP');
-eq(~0xFF & 0x80, 0, 'not operator');
+tap.eq(~0x7f, -128, 'not operator #SKIP');
+tap.eq(~0xFF, -256, 'not operator #SKIP');
+tap.eq(~0, -1, 'not operator #SKIP');
+tap.eq(~(-0x80), 127, 'not operator #SKIP');
+tap.eq(~0xFF & 0x80, 0, 'not operator');
 
-ok((1 << 0) == 1, "1 << 0");
-ok((1 << 8) == 256, "1 << 8");
-ok((1 << 40) == 256, "1 << 256");
-ok((256 >>> 8) == 1, "256 >>> 8");
-ok((-256 >>> 8) == 16777215, "-256 >>> 8");
-ok((256 >> 8) == 1, "256 >> 8");
-ok((-256 >> 8) == -1, "-256 >> 8");
-ok((0x87654321 << 12) == 0x54321000, "0x87654321 << 12")
-ok((0x87654321 >>> 12) == 0x00087654, "0x87654321 >>> 12")
-ok(((0x87654321 >> 12) >>> 0) == 0xfff87654, "0x87654321 >> 12")
+tap.ok((1 << 0) == 1, "1 << 0");
+tap.ok((1 << 8) == 256, "1 << 8");
+tap.ok((1 << 40) == 256, "1 << 256");
+tap.ok((256 >>> 8) == 1, "256 >>> 8");
+tap.ok((-256 >>> 8) == 16777215, "-256 >>> 8");
+tap.ok((256 >> 8) == 1, "256 >> 8");
+tap.ok((-256 >> 8) == -1, "-256 >> 8");
+tap.ok((0x87654321 << 12) == 0x54321000, "0x87654321 << 12")
+tap.ok((0x87654321 >>> 12) == 0x00087654, "0x87654321 >>> 12")
+tap.ok(((0x87654321 >> 12) >>> 0) == 0xfff87654, "0x87654321 >> 12")
 console.log('#', ((0x87654321 >> 12) >>> 0));
 
-ok((-256 >>> 0) == 0xffffff00, "-256 >>> 0");
+tap.ok((-256 >>> 0) == 0xffffff00, "-256 >>> 0");
 console.log('#', (-256 >>> 0), '==', 0xffffff00);

--- a/test/suite/buffer.js
+++ b/test/suite/buffer.js
@@ -1,7 +1,6 @@
-/* test rig */ var t = 1, tmax = 2
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
+
+tap.count(65);
 
 function arreq (a, b) {
 	if (a.length != b.length) {
@@ -16,16 +15,16 @@ function arreq (a, b) {
 }
 
 var a = new Buffer([5, 6, 7, 8]);
-ok(a.length == 4, 'buffer.length');
-ok(a[3] == 8, 'buffer indexing');
-ok(a[4] == null, 'buffer high indexing');
+tap.ok(a.length == 4, 'buffer.length');
+tap.ok(a[3] == 8, 'buffer indexing');
+tap.ok(a[4] == null, 'buffer high indexing');
 
 a = new Buffer('hello');
-ok(a.length == 5, 'buffer char length');
-ok(a[0] == 104, 'buffer char index');
+tap.ok(a.length == 5, 'buffer char length');
+tap.ok(a[0] == 104, 'buffer char index');
 
 a = new Buffer(100);
-ok(a.length == 100, 'buffer fixed size len')
+tap.ok(a.length == 100, 'buffer fixed size len')
 
 a = new Buffer(100);
 a.fill(0xfe);
@@ -35,12 +34,12 @@ for (var i = 0; i < a.length; i++) {
 		success = false
 	}
 }
-ok(success, 'buffer.fill worked')
+tap.ok(success, 'buffer.fill worked')
 
-ok(Buffer.isBuffer(new Buffer('hello')), 'Buffer.isBuffer succeeds on buffer')
-ok(!Buffer.isBuffer([]), 'Buffer.isBuffer fails on non-buffer (array)')
-ok(!Buffer.isBuffer(''), 'Buffer.isBuffer fails on non-buffer (string)')
-ok(!Buffer.isBuffer(null), 'Buffer.isBuffer fails on non-buffer (null)')
+tap.ok(Buffer.isBuffer(new Buffer('hello')), 'Buffer.isBuffer succeeds on buffer')
+tap.ok(!Buffer.isBuffer([]), 'Buffer.isBuffer fails on non-buffer (array)')
+tap.ok(!Buffer.isBuffer(''), 'Buffer.isBuffer fails on non-buffer (string)')
+tap.ok(!Buffer.isBuffer(null), 'Buffer.isBuffer fails on non-buffer (null)')
 
 a = new Buffer(5);
 a.fill(0xFF)
@@ -50,114 +49,114 @@ a.copy(b, 3, 0, 3)
 for (var i = 0, sum = 0; i < b.length; i++) {
 	sum += b[i]
 }
-ok(sum == 765, 'buffer.copy works')
+tap.ok(sum == 765, 'buffer.copy works')
 
 a = new Buffer([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
 b = a.slice(3, 6)
 for (var i = 0, sum = 0; i < b.length; i++) {
 	sum += b[i]
 }
-ok(b.length == 3, 'buffer.slice length')
-ok(sum == 12, 'buffer.slice works')
+tap.ok(b.length == 3, 'buffer.slice length')
+tap.ok(sum == 12, 'buffer.slice works')
 
 var e = null;
 try {
 	b.copy([1, 2, 3, 4], 3, 0, 3)
 } catch (_e) { e = _e }
-ok(!!e, 'error on buffer copy to non-buffer target')
+tap.ok(!!e, 'error on buffer copy to non-buffer target')
 
 a = new Buffer([0x03, 0xab, 0x23, 0x42])
 for (var i = 0, arr = []; i < a.length + 1; i++) {
 	arr.push(a.readUInt8(i, true))
 }
 console.log('#', arr);
-ok(arreq(arr, [0x03, 0xab, 0x23, 0x42, undefined]), 'readUInt8 and assert work')
+tap.ok(arreq(arr, [0x03, 0xab, 0x23, 0x42, undefined]), 'readUInt8 and assert work')
 
-ok(a.readUInt8(0) == 0x3, 'readUInt8')
-ok(a.readUInt16LE(0) == 43779, 'readUInt16LE')
-ok(a.readUInt16BE(0) == 939, 'readUInt16BE')
-ok(a.readUInt32LE(0) == 1109633795, 'readUInt32LE')
-ok(a.readUInt32BE(0) == 61547330, 'readUInt32BE')
-ok(a.readInt8(0) == 3, 'readInt8')
-ok(a.readInt16LE(0) == -21757, 'readInt16LE')
-ok(a.readInt16BE(0) == 939, 'readInt16BE')
-ok(a.readInt32LE(0) == 1109633795, 'readInt32LE')
-ok(a.readInt32BE(0) == 61547330, 'readInt32BE')
+tap.ok(a.readUInt8(0) == 0x3, 'readUInt8')
+tap.ok(a.readUInt16LE(0) == 43779, 'readUInt16LE')
+tap.ok(a.readUInt16BE(0) == 939, 'readUInt16BE')
+tap.ok(a.readUInt32LE(0) == 1109633795, 'readUInt32LE')
+tap.ok(a.readUInt32BE(0) == 61547330, 'readUInt32BE')
+tap.ok(a.readInt8(0) == 3, 'readInt8')
+tap.ok(a.readInt16LE(0) == -21757, 'readInt16LE')
+tap.ok(a.readInt16BE(0) == 939, 'readInt16BE')
+tap.ok(a.readInt32LE(0) == 1109633795, 'readInt32LE')
+tap.ok(a.readInt32BE(0) == 61547330, 'readInt32BE')
 
 var f = new Buffer([0xFF, 0x00, 0x00, 0x80, 0x3f, 0xFF]);
-ok(f.readFloatLE(1) == 1, 'readFloatLE');
+tap.ok(f.readFloatLE(1) == 1, 'readFloatLE');
 console.log('#', f.readFloatLE(1));
 var f = new Buffer([0xFF, 0x00, 0x00, 0x80, 0x3f, 0xFF].reverse());
-ok(f.readFloatBE(1) == 1, 'readFloatBE');
+tap.ok(f.readFloatBE(1) == 1, 'readFloatBE');
 console.log('#', f.readFloatBE(1));
 var f = new Buffer([0xFF, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0xd5, 0x3f, 0xFF]);
-ok(f.readDoubleLE(1) == 1/3, 'readDoubleLE');
+tap.ok(f.readDoubleLE(1) == 1/3, 'readDoubleLE');
 var f = new Buffer([0xFF, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0xd5, 0x3f, 0xFF].reverse());
-ok(f.readDoubleBE(1) == 1/3, 'readDoubleBE');
+tap.ok(f.readDoubleBE(1) == 1/3, 'readDoubleBE');
 
-ok(a.readUInt16BE(1) == 43811, 'buffer read offsets')
+tap.ok(a.readUInt16BE(1) == 43811, 'buffer read offsets')
 
 var a = new Buffer([0, 0, 0, 0]);
-a.writeUInt8(0xde, 0); ok(a[0] == 0xde, 'writeUInt8');
-a.writeUInt16LE(43779, 0); ok(a.readUInt16LE(0) == 43779, 'writeUInt16LE');
-a.writeUInt16BE(939, 0); ok(a.readUInt16BE(0) == 939, 'writeUInt16BE');
-a.writeUInt32LE(1109633795, 0); ok(a.readUInt32LE(0) == 1109633795, 'writeUInt32LE');
-a.writeUInt32BE(61547330, 0); ok(a.readUInt32BE(0) == 61547330, 'writeUInt32BE');
-a.writeInt8(-25, 0); ok(a.readInt8(0) == -25, 'writeInt8');
-a.writeInt16LE(-21757, 0); ok(a.readInt16LE(0) == -21757, 'writeInt16LE');
-a.writeInt16BE(939, 0); ok(a.readInt16BE(0) == 939, 'writeInt16BE');
-a.writeInt32LE(1109633795, 0); ok(a.readInt32LE(0) == 1109633795, 'writeInt32LE');
-a.writeInt32BE(61547330, 0); ok(a.readInt32BE(0) == 61547330, 'writeInt32BE');
+a.writeUInt8(0xde, 0); tap.ok(a[0] == 0xde, 'writeUInt8');
+a.writeUInt16LE(43779, 0); tap.ok(a.readUInt16LE(0) == 43779, 'writeUInt16LE');
+a.writeUInt16BE(939, 0); tap.ok(a.readUInt16BE(0) == 939, 'writeUInt16BE');
+a.writeUInt32LE(1109633795, 0); tap.ok(a.readUInt32LE(0) == 1109633795, 'writeUInt32LE');
+a.writeUInt32BE(61547330, 0); tap.ok(a.readUInt32BE(0) == 61547330, 'writeUInt32BE');
+a.writeInt8(-25, 0); tap.ok(a.readInt8(0) == -25, 'writeInt8');
+a.writeInt16LE(-21757, 0); tap.ok(a.readInt16LE(0) == -21757, 'writeInt16LE');
+a.writeInt16BE(939, 0); tap.ok(a.readInt16BE(0) == 939, 'writeInt16BE');
+a.writeInt32LE(1109633795, 0); tap.ok(a.readInt32LE(0) == 1109633795, 'writeInt32LE');
+a.writeInt32BE(61547330, 0); tap.ok(a.readInt32BE(0) == 61547330, 'writeInt32BE');
 
 var f = new Buffer(10);
 f.fill(0);
-f.writeFloatLE(1, 1); ok(f.readFloatLE(1) == 1, 'writeFloatLE');
+f.writeFloatLE(1, 1); tap.ok(f.readFloatLE(1) == 1, 'writeFloatLE');
 console.log('#', f, f.readFloatLE(1));
-f.writeFloatBE(1, 1); ok(f.readFloatBE(1) == 1, 'writeFloatBE');
+f.writeFloatBE(1, 1); tap.ok(f.readFloatBE(1) == 1, 'writeFloatBE');
 console.log('#', f, f.readFloatBE(1));
-f.writeDoubleLE(1/3, 1); ok(f.readDoubleLE(1) == 1/3, 'writeDoubleLE');
-f.writeDoubleBE(1/3, 1); ok(f.readDoubleBE(1) == 1/3, 'writeDoubleBE');
+f.writeDoubleLE(1/3, 1); tap.ok(f.readDoubleLE(1) == 1/3, 'writeDoubleLE');
+f.writeDoubleBE(1/3, 1); tap.ok(f.readDoubleBE(1) == 1/3, 'writeDoubleBE');
 
 a.fill(0)
 a.writeInt16LE(-21757, 1);
-ok(a.readUInt8(2) == 171, 'buffer write offsets')
+tap.ok(a.readUInt8(2) == 171, 'buffer write offsets')
 
 var a = new Buffer([1, 2, 3]), b = new Buffer([4, 5, 6]), c = new Buffer([7, 8, 9, 10, 11]);
 var abc = Buffer.concat([a, b, c]);
-ok(abc.length == a.length + b.length + c.length, 'buffer concat length');
-ok(arreq(abc, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]), 'buffer concat works');
-ok(arreq(abc.toJSON(), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]), 'buffer toJSON works');
+tap.ok(abc.length == a.length + b.length + c.length, 'buffer concat length');
+tap.ok(arreq(abc, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]), 'buffer concat works');
+tap.ok(arreq(abc.toJSON(), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]), 'buffer toJSON works');
 
 var b = Buffer([255,255,255,255]);
-ok(b.readUInt8(0) == 0xFF, 'readUInt8(0xff)');
-ok(b.readInt8(0) == -1, 'readInt8(0xff)');
-ok(b.readUInt16LE(0) == 0xFFFF, 'readUInt32LE(0xffff)');
-ok(b.readUInt16BE(0) == 0xFFFF, 'readUInt32BE(0xffff)');
-ok(b.readUInt32LE(0) == 0xFFFFFFFF, 'readUInt32LE(0xffffffff)');
-ok(b.readUInt32BE(0) == 0xFFFFFFFF, 'readUInt32BE(0xffffffff)');
+tap.ok(b.readUInt8(0) == 0xFF, 'readUInt8(0xff)');
+tap.ok(b.readInt8(0) == -1, 'readInt8(0xff)');
+tap.ok(b.readUInt16LE(0) == 0xFFFF, 'readUInt32LE(0xffff)');
+tap.ok(b.readUInt16BE(0) == 0xFFFF, 'readUInt32BE(0xffff)');
+tap.ok(b.readUInt32LE(0) == 0xFFFFFFFF, 'readUInt32LE(0xffffffff)');
+tap.ok(b.readUInt32BE(0) == 0xFFFFFFFF, 'readUInt32BE(0xffffffff)');
 
 
 // encodings
 console.log('\n# hex')
 var b = new Buffer('deadbeefcafebabe', 'hex');
-ok(b.readUInt32BE(0) == 0xdeadbeef, 'hex encoding');
-ok(b.readUInt32BE(4) == 0xcafebabe, 'hex encoding');
+tap.ok(b.readUInt32BE(0) == 0xdeadbeef, 'hex encoding');
+tap.ok(b.readUInt32BE(4) == 0xcafebabe, 'hex encoding');
 console.log('#', '0x' + b.readUInt32BE(0).toString(16), '0x' + b.readUInt32BE(4).toString(16))
-try { new Buffer('gggg', 'hex'); ok(false); } catch (e) { ok(true, 'invalid hex digits'); }
-try { new Buffer('0', 'hex'); ok(false); } catch (e) { ok(true, 'invalid hex length'); }
+try { new Buffer('gggg', 'hex'); tap.ok(false); } catch (e) { tap.ok(true, 'invalid hex digits'); }
+try { new Buffer('0', 'hex'); tap.ok(false); } catch (e) { tap.ok(true, 'invalid hex length'); }
 
 console.log('\n# base64')
 var b = new Buffer('aGVsbG8gd29ybGQ=', 'base64');
-ok(b.toString() == 'hello world', 'base64 encoding (padded)');
+tap.ok(b.toString() == 'hello world', 'base64 encoding (padded)');
 var b = new Buffer('aGVsbG8gd29ybGQ', 'base64');
-ok(b.toString() == 'hello world', 'base64 encoding (not padded)');
+tap.ok(b.toString() == 'hello world', 'base64 encoding (not padded)');
 console.log('#', JSON.stringify(b.toString()));
 
 console.log('\n# encoding')
-ok(new Buffer(new Buffer('hello world').toString('base64'), 'base64').toString() == 'hello world', 'str -> base64 -> str')
+tap.ok(new Buffer(new Buffer('hello world').toString('base64'), 'base64').toString() == 'hello world', 'str -> base64 -> str')
 console.log('#', new Buffer('hello world').toString('base64'))
 console.log('#', new Buffer(new Buffer('hello world').toString('base64'), 'base64'))
-ok(new Buffer(new Buffer('hello world').toString('hex'), 'hex').toString() == 'hello world', 'str -> hex -> str')
+tap.ok(new Buffer(new Buffer('hello world').toString('hex'), 'hex').toString() == 'hello world', 'str -> hex -> str')
 console.log('#', new Buffer('hello world').toString('hex'))
 console.log('#', new Buffer(new Buffer('hello world').toString('hex'), 'hex'))
 
@@ -165,5 +164,5 @@ console.log('#', new Buffer(new Buffer('hello world').toString('hex'), 'hex'))
 var buf = new Buffer(256);
 var len = buf.write('\u00bd + \u00bc = \u00be', 4);
 console.log('#', len + " bytes: " + buf.toString('utf8', 4, 4 + len));
-ok(len == 12, 'written length is 12 byes')
-ok(buf.slice(4, 4 + 12).toString() == '\u00bd + \u00bc = \u00be', 'result was written')
+tap.ok(len == 12, 'written length is 12 byes')
+tap.ok(buf.slice(4, 4 + 12).toString() == '\u00bd + \u00bc = \u00be', 'result was written')

--- a/test/suite/bug-bindnull.js
+++ b/test/suite/bug-bindnull.js
@@ -1,17 +1,14 @@
-/* test rig */ var t = 1, tmax = 2
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
 
-
+tap.count(2);
 
 function Test(testMessage) {
     this.test = testMessage;
 }
 
 function printit(err, obj) {
-    ok(err == null, 'No error');
-    ok(obj.test == 'Success', 'String passed');
+    tap.ok(err == null, 'No error');
+    tap.ok(obj.test == 'Success', 'String passed');
 }
 
 var test = new Test("Success");

--- a/test/suite/bug-forinarray.js
+++ b/test/suite/bug-forinarray.js
@@ -1,13 +1,12 @@
-/* test rig */ var t = 1, tmax = 5
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
+
+tap.count(13);
 
 var arr = [];
 arr.hello = 'hi';
 arr.push(1, 2, 3, 4, 5);
 
-ok(arr[0] == 1, 'first index was null');
+tap.ok(arr[0] == 1, 'first index was null');
 
 var had0 = false;
 for (var i in arr) {
@@ -18,8 +17,8 @@ for (var i in arr) {
 		had0 = true;
 	}
 	
-	ok(typeof i == 'string', 'for..in index is string');
-	ok(arr[i] != null, 'array string index is not null');
+	tap.ok(typeof i == 'string', 'for..in index is string');
+	tap.ok(arr[i] != null, 'array string index is not null');
 }
 
 // console.log('ok')

--- a/test/suite/bug-underscores.js
+++ b/test/suite/bug-underscores.js
@@ -1,14 +1,13 @@
-/* test rig */ var t = 1, tmax = 10
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
 
-_typeof = function () { ok(false, 'typeof overwritten'); }
+tap.count(9);
+
+_typeof = function () { tap.ok(false, 'typeof overwritten'); }
 typeof 5;
 
 var dlow = 6;
 dlow = 5;
-ok(dlow != 6, 'simple variable scoping');
+tap.ok(dlow != 6, 'simple variable scoping');
 
 var d_high;
 d__high = 6;
@@ -16,30 +15,30 @@ d__high = 6;
 	var d_high;
 	d__high = 5;
 })();
-ok(d__high == 5, 'var decl underscores are escaped properly');
+tap.ok(d__high == 5, 'var decl underscores are escaped properly');
 
 var a_b = 'hi';
-ok(a_b == 'hi', 'var underscores');
+tap.ok(a_b == 'hi', 'var underscores');
 
 a_b += ' there';
-ok(a_b == 'hi there', 'var underscores in lvalue of assignment');
+tap.ok(a_b == 'hi there', 'var underscores in lvalue of assignment');
 
-ok(a_b.toUpperCase() == 'HI THERE', 'underscore in lvalue of member expression');
+tap.ok(a_b.toUpperCase() == 'HI THERE', 'underscore in lvalue of member expression');
 
 var c_d = {};
 c_d.cool_beans = 5;
-ok(c_d['cool_beans'] == 5, 'dynamic property values')
+tap.ok(c_d['cool_beans'] == 5, 'dynamic property values')
 
 c_d.func_tastic = function () {
-  ok(true, 'underscore in member and base')
+  tap.ok(true, 'underscore in member and base')
 }
 c_d.func__tastic = function () {
-	ok(false,' underscore in member and base');
+	tap.ok(false,' underscore in member and base');
 }
 c_d.func_tastic();
 
 var actions = ["a", "b", "c", "d", "e", "f", "g"];
 var _n = 1;
-ok(actions[_n] != undefined, 'underscores in member properties not undefined');
+tap.ok(actions[_n] != undefined, 'underscores in member properties not undefined');
 var _j = {_k: 5}
-ok(actions[_j._k] != undefined, 'underscores in member properties in member properties not undefined');
+tap.ok(actions[_j._k] != undefined, 'underscores in member properties in member properties not undefined');

--- a/test/suite/builtin.js
+++ b/test/suite/builtin.js
@@ -1,14 +1,11 @@
-/* test rig */ var t = 1, tmax = 1
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-// console.log(t + '..' + tmax);
+var tap = require('../tap');
 
 var builtin = ['assert', 'buffer', 'child_process', 'crypto', 'dgram', 'events', 'fs', 'http',
 'net', 'os', 'path', 'punycode', 'querystring', 'stream', 'string_decoder', 'tty',
 'url', 'util', 'zlib']
 
-console.log('1..' + (builtin.length+1))
-ok(process.versions.colony, 'running in colony')
+tap.count(builtin.length);
 
 for (var i = 0; i < builtin.length; i++) {
-	ok(require(builtin[i]), builtin[i])
+	tap.ok(require(builtin[i]), builtin[i])
 }

--- a/test/suite/date.js
+++ b/test/suite/date.js
@@ -1,13 +1,10 @@
-/* TAP rig */
-function tap (max) { tap.t = 1; console.log(tap.t + '..' + max); };
-function ok (a, d) { console.log((a ? '' : 'not ') + 'ok', tap.t++, '-', d); }
-function eq (a, b, c) { ok(a == b, String(c) + ': ' + String(a) + ' == ' + String(b)); }
+var tap = require('../tap');
 
-tap(16);
+tap.count(16);
 
-eq(typeof Date.now(), 'number');
+tap.eq(typeof Date.now(), 'number');
 console.log('# typeof Date.now', typeof Date.now())
-eq(typeof Date(),'string');
+tap.eq(typeof Date(),'string');
 console.log(typeof (new Date) == 'object');
 
 if (!(Date.now() > 0)) {
@@ -15,33 +12,33 @@ if (!(Date.now() > 0)) {
 }
 
 var d = new Date();
-eq(d.toString(), Date());
+tap.eq(d.toString(), Date());
 console.log('# toString', d.toString())
-ok(d.getDate() >= 1 && d.getDate() <= 31);
+tap.ok(d.getDate() >= 1 && d.getDate() <= 31);
 console.log('# getDate', d.getDate())
-ok(d.getDay() >= 0 && d.getDay() <= 6);
+tap.ok(d.getDay() >= 0 && d.getDay() <= 6);
 console.log('# getDay', d.getDay())
-ok(d.getFullYear() >= 1);
+tap.ok(d.getFullYear() >= 1);
 console.log('# getFullYear', d.getFullYear())
-ok(d.getHours() >= 0 && d.getHours() <= 23);
+tap.ok(d.getHours() >= 0 && d.getHours() <= 23);
 console.log('# getHours', d.getHours())
-ok(d.getMilliseconds() >= 0 && d.getMilliseconds() <= 999);
+tap.ok(d.getMilliseconds() >= 0 && d.getMilliseconds() <= 999);
 console.log('# getMilliseconds', d.getMilliseconds())
-ok(d.getMinutes() >= 0 && d.getMinutes() <= 59);
+tap.ok(d.getMinutes() >= 0 && d.getMinutes() <= 59);
 console.log('# getMinutes', d.getMinutes())
-ok(d.getMonth() >= 0 && d.getMonth() <= 11);
+tap.ok(d.getMonth() >= 0 && d.getMonth() <= 11);
 console.log('# getMonth', d.getMonth())
-ok(d.getSeconds() >= 0 && d.getSeconds() <= 59);
+tap.ok(d.getSeconds() >= 0 && d.getSeconds() <= 59);
 console.log('# getSeconds', d.getSeconds())
-ok(d.getTime() >= 0);
+tap.ok(d.getTime() >= 0);
 console.log('# getTime', d.getTime())
-ok(d.getYear() >= 0 && d.getYear() <= 200);
+tap.ok(d.getYear() >= 0 && d.getYear() <= 200);
 console.log('# getYear', d.getYear())
 
 var d0 = new Date(0);
-eq(d0.toISOString(), '1970-01-01T00:00:00.000Z');
+tap.eq(d0.toISOString(), '1970-01-01T00:00:00.000Z');
 console.log('# toISOString', d0.toISOString());
-eq(d0.toJSON(), '1970-01-01T00:00:00.000Z');
+tap.eq(d0.toJSON(), '1970-01-01T00:00:00.000Z');
 console.log('# toJSON', d0.toJSON());
 
-eq(new Date("10/Mar/2012:05:00:07 +0000").valueOf(), 1331355607000);
+tap.eq(new Date("10/Mar/2012:05:00:07 +0000").valueOf(), 1331355607000);

--- a/test/suite/defineProperty.js
+++ b/test/suite/defineProperty.js
@@ -1,6 +1,6 @@
-/* test rig */ var t = 1, tmax = 1
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
+var tap = require('../tap');
+
+tap.count(2);
 
 o = {};
 
@@ -8,10 +8,10 @@ Object.defineProperty(o, 'foo', {
   value: 0,
 });
 
-ok(o.foo + 1 === 1, 'falsy value');
+tap.ok(o.foo + 1 === 1, 'falsy value');
 
 Object.defineProperty(o, 'bar', {
   get: function() { return 5; }
 });
 
-ok(o.bar === 5, 'getter');
+tap.ok(o.bar === 5, 'getter');

--- a/test/suite/error.js
+++ b/test/suite/error.js
@@ -1,33 +1,32 @@
-/* test rig */ var t = 1, tmax = 3
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
+
+tap.count(22);
 
 try {
 	throw new Error('ok')
 } catch (e) {
-	ok(e.message == 'ok');
+	tap.ok(e.message == 'ok');
 }
 
 
-ok(Error)
-ok(Error('ok').type == 'Error')
-ok(new Error('ok').type == 'Error')
-ok(EvalError)
-ok(EvalError('ok').type == 'EvalError')
-ok(new EvalError('ok').type == 'EvalError')
-ok(RangeError)
-ok(RangeError('ok').type == 'RangeError')
-ok(new RangeError('ok').type == 'RangeError')
-ok(ReferenceError)
-ok(ReferenceError('ok').type == 'ReferenceError')
-ok(new ReferenceError('ok').type == 'ReferenceError')
-ok(SyntaxError)
-ok(SyntaxError('ok').type == 'SyntaxError')
-ok(new SyntaxError('ok').type == 'SyntaxError')
-ok(TypeError)
-ok(TypeError('ok').type == 'TypeError')
-ok(new TypeError('ok').type == 'TypeError')
-ok(URIError)
-ok(URIError('ok').type == 'URIError')
-ok(new URIError('ok').type == 'URIError')
+tap.ok(Error)
+tap.ok(Error('ok').type == 'Error')
+tap.ok(new Error('ok').type == 'Error')
+tap.ok(EvalError)
+tap.ok(EvalError('ok').type == 'EvalError')
+tap.ok(new EvalError('ok').type == 'EvalError')
+tap.ok(RangeError)
+tap.ok(RangeError('ok').type == 'RangeError')
+tap.ok(new RangeError('ok').type == 'RangeError')
+tap.ok(ReferenceError)
+tap.ok(ReferenceError('ok').type == 'ReferenceError')
+tap.ok(new ReferenceError('ok').type == 'ReferenceError')
+tap.ok(SyntaxError)
+tap.ok(SyntaxError('ok').type == 'SyntaxError')
+tap.ok(new SyntaxError('ok').type == 'SyntaxError')
+tap.ok(TypeError)
+tap.ok(TypeError('ok').type == 'TypeError')
+tap.ok(new TypeError('ok').type == 'TypeError')
+tap.ok(URIError)
+tap.ok(URIError('ok').type == 'URIError')
+tap.ok(new URIError('ok').type == 'URIError')

--- a/test/suite/etters.js
+++ b/test/suite/etters.js
@@ -1,11 +1,10 @@
-/* test rig */ var t = 1, tmax = 9
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
+
+tap.count(8);
 
 var a = {}
 a.hello = 'A'
-ok(a.hello == 'A', 'normal property getter')
+tap.ok(a.hello == 'A', 'normal property getter')
 Object.defineProperties(a, {
   'hello': {
     get: function () {
@@ -14,18 +13,18 @@ Object.defineProperties(a, {
   }
 });
 a.__defineSetter__('hello', function (val) {
-  ok(true, 'called setter');
+  tap.ok(true, 'called setter');
 });
-ok(a.hello == 'B', 'getter defined');
+tap.ok(a.hello == 'B', 'getter defined');
 a.hello = 'C'
-ok(a.hello == 'B', 'setter worked');
+tap.ok(a.hello == 'B', 'setter worked');
 
 var b = {};
 b.hello = 'A';
-ok(b.hello == 'A', 'normal property getter');
+tap.ok(b.hello == 'A', 'normal property getter');
 b.__defineSetter__('hello', function (val) {
-  ok(true, 'setter without getter worked')
+  tap.ok(true, 'setter without getter worked')
 });
-ok(b.hello == null, 'setter removed value #TODO')
+tap.ok(b.hello == null, 'setter removed value #TODO')
 b.hello = 'B';
-ok(b.hello != 'B', 'setter didnt change value')
+tap.ok(b.hello != 'B', 'setter didnt change value')

--- a/test/suite/event-error.js
+++ b/test/suite/event-error.js
@@ -1,8 +1,6 @@
-/* TAP rig */
-function tap (max) { tap.t = 1; console.log(tap.t + '..' + max); };
-function ok (a, d) { console.log((a ? '' : 'not ') + 'ok', tap.t++, '-', d); }
+var tap = require('../tap');
 
-tap(4);
+tap.count(4);
 
 var EventEmitter = require('events').EventEmitter;
 
@@ -11,23 +9,23 @@ var a = new EventEmitter
 try {
 	a.emit('error', 'some error')
 } catch (e) {
-	ok(e instanceof TypeError);
+	tap.ok(e instanceof TypeError);
 }
 
 try {
 	a.emit('error', new RangeError('some error'))
 } catch (e) {
-	ok(e instanceof RangeError);
+	tap.ok(e instanceof RangeError);
 }
 
 a.once('error', function (err) {
-	ok(typeof err == 'string');
+	tap.ok(typeof err == 'string');
 });
 
 a.emit('error', 'some error')
 
 a.once('error', function (err) {
-	ok(err instanceof SyntaxError);
+	tap.ok(err instanceof SyntaxError);
 });
 
 a.emit('error', new SyntaxError('some error'))

--- a/test/suite/fs.js
+++ b/test/suite/fs.js
@@ -1,72 +1,70 @@
-/* TAP rig */
-function tap (max) { tap.t = 1; console.log(tap.t + '..' + max); };
-function ok (a, d) { console.log((a ? '' : 'not ') + 'ok', tap.t++, '-', d); }
+var tap = require('../tap');
 
-tap(29);
+tap.count(29);
 
 var fs = require('fs');
 var util = require('util');
 
-ok(Buffer.isBuffer(fs.readFileSync(__dirname + '/files_fs/hello.txt')), 'fs.readFileSync is buffer')
-ok(typeof fs.readFileSync(__dirname + '/files_fs/hello.txt', 'utf-8') == 'string', 'fs.readFileSync accepts encoding')
-ok(util.isArray(fs.readdirSync(__dirname + '/files_fs/')), 'fs.readdirSync is array')
-// ok(fs.readdirSync(__dirname).indexOf('node_modules') > -1, '# TODO node_modules should exist?');
+tap.ok(Buffer.isBuffer(fs.readFileSync(__dirname + '/files_fs/hello.txt')), 'fs.readFileSync is buffer')
+tap.ok(typeof fs.readFileSync(__dirname + '/files_fs/hello.txt', 'utf-8') == 'string', 'fs.readFileSync accepts encoding')
+tap.ok(util.isArray(fs.readdirSync(__dirname + '/files_fs/')), 'fs.readdirSync is array')
+// tap.ok(fs.readdirSync(__dirname).indexOf('node_modules') > -1, '# TODO node_modules should exist?');
 
 var output = __dirname + '/files_fs/output.txt';
 var output2 = __dirname + '/files_fs/output2.txt';
 
 var peeped = 'YOU MIGHT THINK YOUVE PEEPED THE SCENE\n', havent = 'YOU HAVENT\n';
 fs.writeFileSync(output, peeped);
-ok(fs.readFileSync(output, 'utf-8') == peeped, 'writeFileSync == readFileSync of same file');
+tap.ok(fs.readFileSync(output, 'utf-8') == peeped, 'writeFileSync == readFileSync of same file');
 fs.appendFileSync(output, havent);
-ok(fs.readFileSync(output, 'utf-8') == peeped + havent, 'appendFileSync works');
+tap.ok(fs.readFileSync(output, 'utf-8') == peeped + havent, 'appendFileSync works');
 
-ok(fs.readdirSync(__dirname + '/files_fs').indexOf('output.txt') > -1, 'written file exists in readdirSync');
-ok(fs.existsSync(output) == true, 'written file exists');
+tap.ok(fs.readdirSync(__dirname + '/files_fs').indexOf('output.txt') > -1, 'written file exists in readdirSync');
+tap.ok(fs.existsSync(output) == true, 'written file exists');
 fs.unlinkSync(output)
-ok(fs.readdirSync(__dirname + '/files_fs').indexOf('output.txt') == -1, 'unlinked file no longer in readdirSync');
-ok(fs.existsSync(output) == false, 'deleted file no longer exists');
+tap.ok(fs.readdirSync(__dirname + '/files_fs').indexOf('output.txt') == -1, 'unlinked file no longer in readdirSync');
+tap.ok(fs.existsSync(output) == false, 'deleted file no longer exists');
 
 fs.writeFileSync(output, 'THE WATERED DOWN ONE, THE ONE YOU KNOW\n');
-ok(fs.readdirSync(__dirname + '/files_fs').indexOf('output.txt') > -1, 'written file exists in readdirSync...');
+tap.ok(fs.readdirSync(__dirname + '/files_fs').indexOf('output.txt') > -1, 'written file exists in readdirSync...');
 fs.renameSync(output, output2);
-ok(fs.existsSync(output) == false, 'renamed file doesnt still exist');
-ok(fs.existsSync(output2) == true, 'but under its new name does');
-ok(fs.readdirSync(__dirname + '/files_fs').indexOf('output2.txt') > -1, 'and is in new position');
+tap.ok(fs.existsSync(output) == false, 'renamed file doesnt still exist');
+tap.ok(fs.existsSync(output2) == true, 'but under its new name does');
+tap.ok(fs.readdirSync(__dirname + '/files_fs').indexOf('output2.txt') > -1, 'and is in new position');
 fs.unlinkSync(output2);
 
 var centuries = 'WAS MADE UP CENTURIES AGO\n';
 fs.writeFileSync(output, centuries);
-ok(fs.readFileSync(output).length == centuries.length, 'file length matches writeFileSync');
+tap.ok(fs.readFileSync(output).length == centuries.length, 'file length matches writeFileSync');
 fs.truncateSync(output);
-ok(fs.readFileSync(output).length == 0, 'truncated file length is 0');
+tap.ok(fs.readFileSync(output).length == 0, 'truncated file length is 0');
 fs.unlinkSync(output);
 
 // make and delete a directory
 var dir = __dirname + '/files_fs/theymadeitsound';
 var dirchild = __dirname + '/files_fs/theymadeitsound/allwackandcorny';
 console.log('# mkdir');
-ok(fs.readdirSync(__dirname + '/files_fs').indexOf('theymadeitsound') == -1, 'mkdir before is missing');
+tap.ok(fs.readdirSync(__dirname + '/files_fs').indexOf('theymadeitsound') == -1, 'mkdir before is missing');
 fs.mkdirSync(dir);
-ok(fs.readdirSync(__dirname + '/files_fs').indexOf('theymadeitsound') > -1, 'mkdir after is there');
+tap.ok(fs.readdirSync(__dirname + '/files_fs').indexOf('theymadeitsound') > -1, 'mkdir after is there');
 try {
 	fs.unlinkSync(dir);
-	ok(false, 'you should not be able to unlink dir')
+	tap.ok(false, 'you should not be able to unlink dir')
 } catch (e) {
-	ok(true, 'cannot unlink dir')
+	tap.ok(true, 'cannot unlink dir')
 }
 fs.writeFileSync(dirchild, 'YES ITS AWFUL BLASTED BORING\n');
-ok(fs.readdirSync(dir).indexOf('allwackandcorny') > -1, 'mkdir inside mkdir works');
+tap.ok(fs.readdirSync(dir).indexOf('allwackandcorny') > -1, 'mkdir inside mkdir works');
 try {
 	fs.rmdirSync(dir);
-	ok(false, 'you should not be able to remove non-empty dir')
+	tap.ok(false, 'you should not be able to remove non-empty dir')
 } catch (e) {
-	ok(true, 'cannot rmdir non-empty dir')
+	tap.ok(true, 'cannot rmdir non-empty dir')
 }
 fs.unlinkSync(dirchild);
-ok(fs.readdirSync(dir).indexOf('allwackandcorny') == -1, 'child dir file can be unlinked');
+tap.ok(fs.readdirSync(dir).indexOf('allwackandcorny') == -1, 'child dir file can be unlinked');
 fs.rmdirSync(dir);
-ok(fs.readdirSync(__dirname + '/files_fs').indexOf('theymadeitsound') == -1, 'delete dir after empty');
+tap.ok(fs.readdirSync(__dirname + '/files_fs').indexOf('theymadeitsound') == -1, 'delete dir after empty');
 console.log('');
 
 // stats
@@ -74,13 +72,13 @@ console.log('# stats');
 var twisted = 'TWISTED FICTION\n';
 fs.writeFileSync(output, twisted);
 var stat = fs.statSync(output);
-ok(stat.size == twisted.length, 'filesize of written file is correct');
+tap.ok(stat.size == twisted.length, 'filesize of written file is correct');
 console.log('#', stat.size, twisted.length)
-ok(stat.isFile() == true, 'file isFile');
-ok(stat.isDirectory() == false, 'file isDirectory');
+tap.ok(stat.isFile() == true, 'file isFile');
+tap.ok(stat.isDirectory() == false, 'file isDirectory');
 var stat = fs.statSync(__dirname + '/files_fs/');
-ok(stat.isFile() == false, 'dir isFile')
-ok(stat.isDirectory() == true, 'dir isDirectory');
+tap.ok(stat.isFile() == false, 'dir isFile')
+tap.ok(stat.isDirectory() == true, 'dir isDirectory');
 fs.unlinkSync(output);
 console.log('');
 
@@ -89,10 +87,10 @@ setImmediate(function () {
 	var sick = 'SICK ADDICTION';
 	fs.writeFileSync(output, sick);
 	fs.readFile(output, 'utf-8', function (err, str) {
-		ok(str == sick, 'readFile is async and works');
+		tap.ok(str == sick, 'readFile is async and works');
 		fs.unlinkSync(output);
 		fs.readFile(output, 'utf-8', function (err, str) {
-			ok(err, 'readFile can return (not throw) err');
+			tap.ok(err, 'readFile can return (not throw) err');
 		});
 	})
 })

--- a/test/suite/function.js
+++ b/test/suite/function.js
@@ -1,15 +1,14 @@
-/* test rig */ var t = 1, tmax = 4
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
+
+tap.count(3);
 
 function a (a, b, c, d, e) { }
-ok(a.length == 5, 'function arity == 5')
-ok(new Function(), 'empty Function() constructor')
+tap.eq(a.length, 5, 'function arity == 5')
+tap.ok(new Function(), 'empty Function() constructor')
 
 try {
   var b = new Function("a", "b", "console.log('')")
-  ok(false, 'new Function() does not throw error')
+  tap.ok(false, 'new Function() does not throw error')
 } catch(err) {
-  ok(true, 'new Function(arg) throws error')
+  tap.ok(true, 'new Function(arg) throws error')
 }

--- a/test/suite/hasOwnProperty.js
+++ b/test/suite/hasOwnProperty.js
@@ -1,22 +1,22 @@
-/* test rig */ var t = 1, tmax = 7
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
+var tap = require('../tap');
+
+tap.count(9);
 
 var a = {x: 5}
-ok(a.hasOwnProperty('x') === true, 'object hasOwnProperty positive')
-ok(a.hasOwnProperty('y') === false, 'object hasOwnProperty negative')
-ok(a.hasOwnProperty('hasOwnProperty') === false, 'object hasOwnProperty prototype')
+tap.eq(a.hasOwnProperty('x'), true, 'object hasOwnProperty positive')
+tap.eq(a.hasOwnProperty('y'), false, 'object hasOwnProperty negative')
+tap.eq(a.hasOwnProperty('hasOwnProperty'), false, 'object hasOwnProperty prototype')
 
 var f = function(){};
 f.foo = 1
-ok(f.hasOwnProperty('foo') === true, 'function hasOwnProperty positive')
-ok(f.hasOwnProperty('bar') === false, 'function hasOwnProperty negative')
+tap.eq(f.hasOwnProperty('foo'), true, 'function hasOwnProperty positive')
+tap.eq(f.hasOwnProperty('bar'), false, 'function hasOwnProperty negative')
 
 var b = new Buffer(1);
 b.foo = 1;
-ok(b.hasOwnProperty('foo') === true, 'buffer hasOwnProperty positive')
-ok(b.hasOwnProperty('bar') === false, 'buffer hasOwnProperty negative')
+tap.eq(b.hasOwnProperty('foo'), true, 'buffer hasOwnProperty positive')
+tap.eq(b.hasOwnProperty('bar'), false, 'buffer hasOwnProperty negative')
 
 var s = 'string';
-ok(s.hasOwnProperty('length') === true, 'string hasOwnProperty positive')
-ok(s.hasOwnProperty('bar') === false, 'string hasOwnProperty negative')
+tap.eq(s.hasOwnProperty('length'), true, 'string hasOwnProperty positive')
+tap.eq(s.hasOwnProperty('bar'), false, 'string hasOwnProperty negative')

--- a/test/suite/json.js
+++ b/test/suite/json.js
@@ -1,7 +1,6 @@
-/* test rig */ var t = 1, tmax = 8
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
+
+tap.count(16);
 
 function arreq (a, b) {
 	if (a.length != b.length) {
@@ -16,27 +15,27 @@ function arreq (a, b) {
 }
 
 var obj = JSON.parse("{\"hi\": 5}");
-ok(obj.hi == 5, 'json parse object')
+tap.ok(obj.hi == 5, 'json parse object')
 
 var obj = JSON.parse("[0, 1, 2]");
 console.log('#', JSON.parse("[0, 1, 2]"), JSON.parse("[0, 1, 2]").length)
-ok(arreq(obj, [0,1,2]), 'json parse array');
+tap.ok(arreq(obj, [0,1,2]), 'json parse array');
 
-ok(JSON.parse("{\"hi\": 5}").hasOwnProperty, 'json object is real object');
-ok(JSON.parse("[0, 1, 2]").slice, 'json array is real array');
+tap.ok(JSON.parse("{\"hi\": 5}").hasOwnProperty, 'json object is real object');
+tap.ok(JSON.parse("[0, 1, 2]").slice, 'json array is real array');
 
 console.log('#', JSON.stringify([0, 1, 2]))
-ok(JSON.stringify([0, 1, 2]) == '[0,1,2]', 'stringify array');
-ok(JSON.stringify({a: function () {}, b: 5}) == '{"b":5}', 'stringify fn #TODO functions should not be output');
-ok(JSON.stringify({"hi": 5}) == "{\"hi\":5}", 'stringify obj');
+tap.ok(JSON.stringify([0, 1, 2]) == '[0,1,2]', 'stringify array');
+tap.ok(JSON.stringify({a: function () {}, b: 5}) == '{"b":5}', 'stringify fn #TODO functions should not be output');
+tap.ok(JSON.stringify({"hi": 5}) == "{\"hi\":5}", 'stringify obj');
 
-ok(JSON.stringify(Object()) == '{}', 'empty obj')
-ok(JSON.stringify([]) == '[]', 'empty array #TODO')
+tap.ok(JSON.stringify(Object()) == '{}', 'empty obj')
+tap.ok(JSON.stringify([]) == '[]', 'empty array #TODO')
 
-ok(JSON.stringify({hi : 5}, null, '  ') == '{\n  "hi": 5\n}\n', 'indentation formatting');
+tap.ok(JSON.stringify({hi : 5}, null, '  ') == '{\n  "hi": 5\n}\n', 'indentation formatting');
 
 function censor(key, value) {
-	ok(this[key] == value, '"this" value correct in replacer');
+	tap.ok(this[key] == value, '"this" value correct in replacer');
   if (typeof(value) == "string") {
     return undefined;
   }
@@ -44,5 +43,5 @@ function censor(key, value) {
 }
 var foo = {foundation: "Mozilla", model: "box", week: 45, transport: "car", month: 7};
 var jsonString = JSON.stringify(foo, censor);
-ok(jsonString == '{"week":45,"month":7}', 'json replacer works')
+tap.ok(jsonString == '{"week":45,"month":7}', 'json replacer works')
 console.log('#', jsonString);

--- a/test/suite/jsonload.js
+++ b/test/suite/jsonload.js
@@ -1,7 +1,6 @@
-/* test rig */ var t = 1, tmax = 2
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
 
-ok(require('./jsonload-json').hello == 'hi', 'json imported');
-ok(require('./jsonload-json.json').hello == 'hi', 'json imported explicitly');
+tap.count(2);
+
+tap.eq(require('./jsonload-json').hello, 'hi', 'json imported');
+tap.eq(require('./jsonload-json.json').hello, 'hi', 'json imported explicitly');

--- a/test/suite/math.js
+++ b/test/suite/math.js
@@ -1,105 +1,104 @@
-/* test rig */ var t = 1, tmax = 2
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
+
+tap.count(69);
 
 // number encoding
-ok(0644 == 420, 'octal encoding');
+tap.ok(0644 == 420, 'octal encoding');
 
 // variables
-ok(Math.E == 2.718281828459045, 'Math.E')
-ok(Math.LN2 == 0.6931471805599453, 'Math.LN2')
-ok(Math.LN10 == 2.302585092994046, 'Math.LN10')
-ok(Math.LOG2E == 1.4426950408889634, 'Math.LOG2E')
-ok(Math.LOG10E == 0.4342944819032518, 'Math.LOG10E')
-ok(Math.PI == 3.141592653589793, 'Math.PI')
-ok(Math.SQRT1_2 == 0.7071067811865476, 'Math.SQRT1_2')
-ok(Math.SQRT2 == 1.4142135623730951, 'Math.SQRT2')
+tap.ok(Math.E == 2.718281828459045, 'Math.E')
+tap.ok(Math.LN2 == 0.6931471805599453, 'Math.LN2')
+tap.ok(Math.LN10 == 2.302585092994046, 'Math.LN10')
+tap.ok(Math.LOG2E == 1.4426950408889634, 'Math.LOG2E')
+tap.ok(Math.LOG10E == 0.4342944819032518, 'Math.LOG10E')
+tap.ok(Math.PI == 3.141592653589793, 'Math.PI')
+tap.ok(Math.SQRT1_2 == 0.7071067811865476, 'Math.SQRT1_2')
+tap.ok(Math.SQRT2 == 1.4142135623730951, 'Math.SQRT2')
 
 // clz32
-ok(Math.clz32(nil) == 32, 'Math.clz32(nil)')
-ok(Math.clz32(1) == 31, 'Math.clz32(1)')
-ok(Math.clz32(1000) == 22, 'Math.clz32(22)')
-ok(Math.clz32(true) == 31, 'Math.clz32(true)')
-ok(Math.clz32(3.5) == 30, 'Math.clz32(3.5)')
-ok(Math.clz32(-3.5) == 0, 'Math.clz32(-3.5)')
-ok([NaN, Infinity, -Infinity, 0, -0, null, undefined, "foo", {}, []].filter(function (n) {
+tap.ok(Math.clz32(nil) == 32, 'Math.clz32(nil)')
+tap.ok(Math.clz32(1) == 31, 'Math.clz32(1)')
+tap.ok(Math.clz32(1000) == 22, 'Math.clz32(22)')
+tap.ok(Math.clz32(true) == 31, 'Math.clz32(true)')
+tap.ok(Math.clz32(3.5) == 30, 'Math.clz32(3.5)')
+tap.ok(Math.clz32(-3.5) == 0, 'Math.clz32(-3.5)')
+tap.ok([NaN, Infinity, -Infinity, 0, -0, null, undefined, "foo", {}, []].filter(function (n) {
   return Math.clz32(n) !== 32
 }).length == 0, 'Math.clz32([NaN, Infinity, -Infinity, 0, -0, null, undefined, "foo", {}, []])')
 
 // sign
-ok(Math.sign(3) == 1, 'Math.sign(3)')
-ok(Math.sign(-3) == -1, 'Math.sign(-3)')
-ok(Math.sign('-3') == -1, 'Math.sign("-3")')
-ok(Math.sign(0) == 0, 'Math.sign(0)')
-ok(Math.sign(-0) == -0, 'Math.sign(-0)')
-ok(isNaN(Math.sign(NaN)), 'Math.sign(NaN)')
-ok(isNaN(Math.sign("foo")), 'Math.sign("foo")')
-ok(isNaN(Math.sign()), 'Math.sign()')
+tap.ok(Math.sign(3) == 1, 'Math.sign(3)')
+tap.ok(Math.sign(-3) == -1, 'Math.sign(-3)')
+tap.ok(Math.sign('-3') == -1, 'Math.sign("-3")')
+tap.ok(Math.sign(0) == 0, 'Math.sign(0)')
+tap.ok(Math.sign(-0) == -0, 'Math.sign(-0)')
+tap.ok(isNaN(Math.sign(NaN)), 'Math.sign(NaN)')
+tap.ok(isNaN(Math.sign("foo")), 'Math.sign("foo")')
+tap.ok(isNaN(Math.sign()), 'Math.sign()')
 
 // tanh
-ok(Math.tanh(0) == 0, 'Math.tanh(0)')
-ok(Math.tanh(Infinity) == 1, 'Math.tanh(Infinity)')
-ok(Math.tanh(1) == 0.7615941559557649, 'Math.tanh(1)')
+tap.ok(Math.tanh(0) == 0, 'Math.tanh(0)')
+tap.ok(Math.tanh(Infinity) == 1, 'Math.tanh(Infinity)')
+tap.ok(Math.tanh(1) == 0.7615941559557649, 'Math.tanh(1)')
 
 // trunc
-ok(Math.trunc(13.37) == 13, 'Math.trunc(13.37)')
-ok(Math.trunc(42.84) == 42, 'Math.trunc(42.84)')
-ok(Math.trunc(0.123) ==  0, 'Math.trunc(0.123)')
-ok(Math.trunc(-0.123) == -0, 'Math.trunc(-0.123)')
-ok(Math.trunc("-1.123") == -1, 'Math.trunc("-1.123")')
-ok(isNaN(Math.trunc(NaN)), 'Math.trunc(NaN)')
-ok(isNaN(Math.trunc("foo")), 'Math.trunc("foo")')
-ok(isNaN(Math.trunc()), 'Math.trunc()')
+tap.ok(Math.trunc(13.37) == 13, 'Math.trunc(13.37)')
+tap.ok(Math.trunc(42.84) == 42, 'Math.trunc(42.84)')
+tap.ok(Math.trunc(0.123) ==  0, 'Math.trunc(0.123)')
+tap.ok(Math.trunc(-0.123) == -0, 'Math.trunc(-0.123)')
+tap.ok(Math.trunc("-1.123") == -1, 'Math.trunc("-1.123")')
+tap.ok(isNaN(Math.trunc(NaN)), 'Math.trunc(NaN)')
+tap.ok(isNaN(Math.trunc("foo")), 'Math.trunc("foo")')
+tap.ok(isNaN(Math.trunc()), 'Math.trunc()')
 
 // log2
-ok(Math.log2(3) == 1.5849625007211563, 'Math.log2(3)') // TODO check this value against ES6
-ok(Math.log2(2) == 1, 'Math.log2(2)')
-ok(Math.log2(1) == 0, 'Math.log2(1)')
-ok(Math.log2(0) == -Infinity, 'Math.log2(0)')
-ok(isNaN(Math.log2(-2)), 'Math.log2(-2)')
-ok(Math.log2(1024) == 10, 'Math.log2(1024)')
+tap.ok(Math.log2(3) == 1.5849625007211563, 'Math.log2(3)') // TODO check this value against ES6
+tap.ok(Math.log2(2) == 1, 'Math.log2(2)')
+tap.ok(Math.log2(1) == 0, 'Math.log2(1)')
+tap.ok(Math.log2(0) == -Infinity, 'Math.log2(0)')
+tap.ok(isNaN(Math.log2(-2)), 'Math.log2(-2)')
+tap.ok(Math.log2(1024) == 10, 'Math.log2(1024)')
 
 // fround
-ok(Math.fround(0) == 0, 'Math.fround(0)')
-ok(Math.fround(1) == 1, 'Math.fround(1)')
-ok(Math.fround(1.337) == 1.3370000123977661, 'Math.fround(1.337)')
-ok(Math.fround(1.5) == 1.5, 'Math.fround(1.5)')
-ok(isNaN(Math.fround(NaN)), 'Math.fround(NaN)')
+tap.ok(Math.fround(0) == 0, 'Math.fround(0)')
+tap.ok(Math.fround(1) == 1, 'Math.fround(1)')
+tap.ok(Math.fround(1.337) == 1.3370000123977661, 'Math.fround(1.337)')
+tap.ok(Math.fround(1.5) == 1.5, 'Math.fround(1.5)')
+tap.ok(isNaN(Math.fround(NaN)), 'Math.fround(NaN)')
 
 // log1p
-ok(Math.log1p(1) == 0.6931471805599453, 'Math.log1p(1)')
-ok(Math.log1p(0) == 0, 'Math.log1p(0)')
-ok(Math.log1p(-1) == -Infinity, 'Math.log1p(-1)')
-ok(isNaN(Math.log1p(-2)), 'Math.log1p(-2)')
+tap.ok(Math.log1p(1) == 0.6931471805599453, 'Math.log1p(1)')
+tap.ok(Math.log1p(0) == 0, 'Math.log1p(0)')
+tap.ok(Math.log1p(-1) == -Infinity, 'Math.log1p(-1)')
+tap.ok(isNaN(Math.log1p(-2)), 'Math.log1p(-2)')
 
 // hypot
-ok(Math.hypot(3, 4) == 5, 'Math.hypot(3, 4)')
-ok(Math.hypot(3, 4, 5) == 7.0710678118654755, 'Math.hypot(3, 4, 5)')
-ok(Math.hypot() == 0, 'Math.hypot()')
-ok(isNaN(Math.hypot(NaN)), 'Math.hypot(NaN)')
-ok(isNaN(Math.hypot(3, 4, "foo")), 'Math.hypot(3, 4, "foo")')
-ok(Math.hypot(3, 4, "5") == 7.0710678118654755, 'Math.hypot(3, 4, "5")')
-ok(Math.hypot(-3) == 3, 'Math.hypot(-3)')
+tap.ok(Math.hypot(3, 4) == 5, 'Math.hypot(3, 4)')
+tap.ok(Math.hypot(3, 4, 5) == 7.0710678118654755, 'Math.hypot(3, 4, 5)')
+tap.ok(Math.hypot() == 0, 'Math.hypot()')
+tap.ok(isNaN(Math.hypot(NaN)), 'Math.hypot(NaN)')
+tap.ok(isNaN(Math.hypot(3, 4, "foo")), 'Math.hypot(3, 4, "foo")')
+tap.ok(Math.hypot(3, 4, "5") == 7.0710678118654755, 'Math.hypot(3, 4, "5")')
+tap.ok(Math.hypot(-3) == 3, 'Math.hypot(-3)')
 
 // imul
-ok(Math.imul(2, 4) == 8, 'Math.imul(2, 4)')
-ok(Math.imul(-1, 8) == -8, 'Math.imul(-1, 8)')
-ok(Math.imul(-2, -2) == 4, 'Math.imul(-2, -2)')
-ok(Math.imul(0xffffffff, 5) == -5, 'Math.imul(0xffffffff, 5)')
-ok(Math.imul(0xfffffffe, 5) == -10, 'Math.imul(0xfffffffe, 5)')
+tap.ok(Math.imul(2, 4) == 8, 'Math.imul(2, 4)')
+tap.ok(Math.imul(-1, 8) == -8, 'Math.imul(-1, 8)')
+tap.ok(Math.imul(-2, -2) == 4, 'Math.imul(-2, -2)')
+tap.ok(Math.imul(0xffffffff, 5) == -5, 'Math.imul(0xffffffff, 5)')
+tap.ok(Math.imul(0xfffffffe, 5) == -10, 'Math.imul(0xfffffffe, 5)')
 
 // round
-ok(Math.round(20.49) == 20, 'Math.round(20.49)')
-ok(Math.round(20.5) == 21, 'Math.round(20.5)')
-ok(Math.round(-20.5) == -20, 'Math.round(-20.5)')
-ok(Math.round(-20.51) == -21, 'Math.round(-20.51)')
+tap.ok(Math.round(20.49) == 20, 'Math.round(20.49)')
+tap.ok(Math.round(20.5) == 21, 'Math.round(20.5)')
+tap.ok(Math.round(-20.5) == -20, 'Math.round(-20.5)')
+tap.ok(Math.round(-20.51) == -21, 'Math.round(-20.51)')
 // Note the rounding error because of inaccurate floating point arithmetics
-ok((Math.round(1.005*100)/100) == 1, 'Math.round(1.005*100)/100');
+tap.ok((Math.round(1.005*100)/100) == 1, 'Math.round(1.005*100)/100');
 
 // etc
-ok(Math.pow(2, 2) == 4, 'Math.pow')
+tap.ok(Math.pow(2, 2) == 4, 'Math.pow')
 
 // nan
 console.log('#', String(0/0))
-ok(String(0/0) == 'NaN', 'NaN is NaN and not nan');
+tap.ok(String(0/0) == 'NaN', 'NaN is NaN and not nan');

--- a/test/suite/parse-numbers.js
+++ b/test/suite/parse-numbers.js
@@ -1,25 +1,24 @@
-/* test rig */ var t = 1, tmax = 4
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
+
+tap.count(13);
 
 var s = '10';
-ok(parseInt(s,10) == 10);
-ok(parseFloat(s,10) == 10);
+tap.ok(parseInt(s,10) == 10);
+tap.ok(parseFloat(s,10) == 10);
 console.log("# base 10:", parseInt(s,10));
-ok(parseInt(s,16) == 16);
-ok(parseFloat(s,16) == 10);
+tap.ok(parseInt(s,16) == 16);
+tap.ok(parseFloat(s,16) == 10);
 console.log("# base 16:", parseInt(s,16));
-ok(parseInt(s,2) == 2);
-ok(parseFloat(s,2) == 10);
+tap.ok(parseInt(s,2) == 2);
+tap.ok(parseFloat(s,2) == 10);
 console.log("# base  2:", parseInt(s,2));
 
-ok(parseInt('0399') == 399, 'octal int');
-ok(parseFloat('0399') == 399, 'octal float');
+tap.ok(parseInt('0399') == 399, 'octal int');
+tap.ok(parseFloat('0399') == 399, 'octal float');
 
 // stress test invalid radixes
-ok(parseInt(s,0) == 10, 'radix 0');
-ok(isNaN(parseInt(s,37)));
-ok(isNaN(parseInt(s,1)));
-ok(isNaN(parseInt(s,"1")));
-ok(!isNaN(parseFloat(s,0)));
+tap.ok(parseInt(s,0) == 10, 'radix 0');
+tap.ok(isNaN(parseInt(s,37)));
+tap.ok(isNaN(parseInt(s,1)));
+tap.ok(isNaN(parseInt(s,"1")));
+tap.ok(!isNaN(parseFloat(s,0)));

--- a/test/suite/primitive.js
+++ b/test/suite/primitive.js
@@ -1,87 +1,86 @@
-/* test rig */ var t = 1, tmax = 3
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-// console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
 
-ok(null < 400, 'null < positive');
-ok(!(5 < null), 'positive < null');
-ok(null > -400, 'null > negative');
-ok(!(null > 0), 'null not > 0');
-ok(!(null < 0), 'null not < 0');
-ok(null != 0, 'null != 0');
-ok(!(null < null), 'null < null')
-ok(!(null > null), 'null > null')
-ok(null == null, 'null == null')
-// ok((null * 5) == 0, 'null * 5')
+tap.count(43);
 
-ok(undefined < 400, 'undefined < positive #TODO');
-ok(undefined > -400, 'undefined > positive #TODO');
+tap.ok(null < 400, 'null < positive');
+tap.ok(!(5 < null), 'positive < null');
+tap.ok(null > -400, 'null > negative');
+tap.ok(!(null > 0), 'null not > 0');
+tap.ok(!(null < 0), 'null not < 0');
+tap.ok(null != 0, 'null != 0');
+tap.ok(!(null < null), 'null < null')
+tap.ok(!(null > null), 'null > null')
+tap.ok(null == null, 'null == null')
+// tap.ok((null * 5) == 0, 'null * 5')
 
-ok(('hasOwnProperty' in {}) == true, 'in works and is boolean');
+tap.ok(undefined < 400, 'undefined < positive #TODO');
+tap.ok(undefined > -400, 'undefined > positive #TODO');
+
+tap.ok(('hasOwnProperty' in {}) == true, 'in works and is boolean');
 
 var b = [1, 2, 3];
 var a = {b: b};
 
-ok(a instanceof Object);
-ok(!(a instanceof Array));
-ok(!(a instanceof Function))
-ok(b instanceof Object)
-ok(b instanceof Array);
-ok(!(b instanceof Function))
-ok(parseFloat instanceof Object)
-ok(!(parseFloat instanceof Array))
-ok(parseFloat instanceof Function)
+tap.ok(a instanceof Object);
+tap.ok(!(a instanceof Array));
+tap.ok(!(a instanceof Function))
+tap.ok(b instanceof Object)
+tap.ok(b instanceof Array);
+tap.ok(!(b instanceof Function))
+tap.ok(parseFloat instanceof Object)
+tap.ok(!(parseFloat instanceof Array))
+tap.ok(parseFloat instanceof Function)
 
 // operators
-ok(('null' << 'null') == 0)
+tap.ok(('null' << 'null') == 0)
 
 // ternary
 var initial = true;
-ok((initial || initial != 'low' ? 'a' : 'a') == 'a', 'ternary works with boolean operators');
+tap.ok((initial || initial != 'low' ? 'a' : 'a') == 'a', 'ternary works with boolean operators');
 
 // void
-ok((void 0) == undefined, 'void')
+tap.ok((void 0) == undefined, 'void')
 
 // isNaN
-ok(isNaN(0/0), 'isNaN');
+tap.ok(isNaN(0/0), 'isNaN');
 
 // Boolean
 Boolean.prototype.cool = function () { return true; }
-ok((true).cool(), 'Boolean prototype exposed');
-ok((false).constructor == Boolean, 'Boolean constructor exposed');
+tap.ok((true).cool(), 'Boolean prototype exposed');
+tap.ok((false).constructor == Boolean, 'Boolean constructor exposed');
 
 // Number
 Number.prototype.cool = function () { return true; }
-ok((1).cool(), 'Number prototype exposed');
-ok((1).constructor == Number, 'Number constructor exposed');
-ok(Number(true) == 1, 'Number(true) == 1')
+tap.ok((1).cool(), 'Number prototype exposed');
+tap.ok((1).constructor == Number, 'Number constructor exposed');
+tap.ok(Number(true) == 1, 'Number(true) == 1')
 
 // String
 String.prototype.cool = function () { return true; }
-ok(("").cool(), 'String prototype exposed');
-ok(("").constructor == String, 'String constructor exposed');
-ok(String(1) == '1', 'String(1) == "1"')
+tap.ok(("").cool(), 'String prototype exposed');
+tap.ok(("").constructor == String, 'String constructor exposed');
+tap.ok(String(1) == '1', 'String(1) == "1"')
 
 // Function
 Function.prototype.cool = function () { return true; }
-ok((function () { }).cool(), 'Function prototype exposed');
-ok((function () { }).constructor == Function, 'Function constructor exposed');
+tap.ok((function () { }).cool(), 'Function prototype exposed');
+tap.ok((function () { }).constructor == Function, 'Function constructor exposed');
 
 // Array
 Array.prototype.cool = function () { return true; }
-ok(([]).cool(), 'Array prototype exposed');
-ok(([]).constructor == Array, 'Array constructor exposed');
+tap.ok(([]).cool(), 'Array prototype exposed');
+tap.ok(([]).constructor == Array, 'Array constructor exposed');
 
 // Regex
 RegExp.prototype.cool = function () { return true; }
-ok((/a/).cool(), 'RegExp prototype exposed');
-ok((/b/).constructor == RegExp, 'RegExp constructor exposed');
+tap.ok((/a/).cool(), 'RegExp prototype exposed');
+tap.ok((/b/).constructor == RegExp, 'RegExp constructor exposed');
 
 // Object 
 // (last because all things inherit from Object)
 Object.prototype.cool = function () { return 'true'; }
-ok(({}).cool(), 'Object prototype exposed');
-ok(({}).constructor == Object, 'Object constructor exposed');
-ok(JSON.stringify(Object()) == '{}', 'Object() constructor')
+tap.ok(({}).cool(), 'Object prototype exposed');
+tap.ok(({}).constructor == Object, 'Object constructor exposed');
+tap.ok(JSON.stringify(Object()) == '{}', 'Object() constructor')
 console.log('#', Object({a: 5}))
-ok(Object({a: 5}).a == 5, 'Object(obj) constructor')
+tap.ok(Object({a: 5}).a == 5, 'Object(obj) constructor')

--- a/test/suite/regex.js
+++ b/test/suite/regex.js
@@ -1,12 +1,11 @@
-/* test rig */ var t = 1, tmax = 9
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
 
-ok("garbage 09 _ - !@#$%".match(/^[\s\S]+$/), 'regex match');
+tap.count(13);
 
-ok("a".match(/^[\S]+$/), '\\S in class matches non-whitespace');
-ok(!" ".match(/^[\S]+$/), '\\S in class does not match whitespace');
+tap.ok("garbage 09 _ - !@#$%".match(/^[\s\S]+$/), 'regex match');
+
+tap.ok("a".match(/^[\S]+$/), '\\S in class matches non-whitespace');
+tap.ok(!" ".match(/^[\S]+$/), '\\S in class does not match whitespace');
 
 // socket.js
 var a = /([^:]+)/;
@@ -15,12 +14,12 @@ var a = /([^:]+):([0-9]+)?(\+)?:/;
 var a = /([^:]+):([0-9]+)?(\+)?:([^:]+)?:?/;
 var a = /([^:]+):([0-9]+)?(\+)?:([^:]+)?:?([\d]*)/;
 var a = /([^:]+):([0-9]+)?(\+)?:([^:]+)?:?([\s\S]*)?/;
-ok(true, 'regex compilation from connect socket.js');
+tap.ok(true, 'regex compilation from connect socket.js');
 
 // path.js
 var a = /^(\/?|)((?:\.{1,2}|[^\/]+?|)(\.[^.\/]*|))(?:[\/]*)$/;
 var a = /^(\/?|)([\s\S]*?)((?:\.{1,2}|[^\/]+?|)(\.[^.\/]*|))(?:[\/]*)$/;
-ok(true,  'regex compilation from path.js')
+tap.ok(true,  'regex compilation from path.js')
 
 // url.js
 var a = /^[a-z]/i;
@@ -28,7 +27,7 @@ var a = /^[a-z]$/i;
 var a = /^[a-z][a-z0-9]*$/i;
 var a = /^[a-z][a-z0-9\-+]*$/i;
 var a = /^[a-z][a-z0-9\-+]*$/i;
-ok(true, 'regex compilation from url.js')
+tap.ok(true, 'regex compilation from url.js')
 
 // more matches
 var subj1 = "there are 99 red balloons";
@@ -36,22 +35,22 @@ var subj2 = "here is a caveaaAEEAAEeaeaEAEaeeaEEAEEAet about regexes."
 var subj3 = " ###    ##     ####  ";
 
 var a = new RegExp("\\d+");
-ok(subj1.match(a), '\\d matches numbers')
+tap.ok(subj1.match(a), '\\d matches numbers')
 
 var b = /(\d+)(\s+)/;
-ok(subj1.match(b), 'matches numbers and whitespace');
+tap.ok(subj1.match(b), 'matches numbers and whitespace');
 
 var c = /cav[ea]+t/i;
-ok(subj2.match(c)[0] == 'caveaaAEEAAEeaeaEAEaeeaEEAEEAet', 'matches char classes');
+tap.ok(subj2.match(c)[0] == 'caveaaAEEAAEeaeaEAEaeeaEEAEEAet', 'matches char classes');
 
-ok(c.test(subj2), 'test() works')
+tap.ok(c.test(subj2), 'test() works')
 
 console.log('#', subj3.replace(/\#+/, '___'));
 console.log('#', subj3.replace(/\#+/g, '___'));
-ok(subj3.replace(/\#+/, '___') == " ___    ##     ####  ", 'non-global replace')
-ok(subj3.replace(/\#+/g, '___') == " ___    ___     ___  ", 'global replace')
+tap.ok(subj3.replace(/\#+/, '___') == " ___    ##     ####  ", 'non-global replace')
+tap.ok(subj3.replace(/\#+/g, '___') == " ___    ___     ___  ", 'global replace')
 
-ok(subj3.replace(/\#(\#*)/g, function (whole, p1, offset, str) {
+tap.ok(subj3.replace(/\#(\#*)/g, function (whole, p1, offset, str) {
   // console.log('-->', whole, p1, offset, str);
   return whole.length
 }) == " 3    2     4  ", 'regex replace with fn');

--- a/test/suite/string.js
+++ b/test/suite/string.js
@@ -1,14 +1,13 @@
-/* test rig */ var t = 1, tmax = 7
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
 
-ok("1234567890".substring(3, 6) == "456", 'substring 1')
-ok("abc".substring(0, 0) == "", 'substring 2')
-ok("ababababab".indexOf('a') == 0, 'indexOf')
-ok("ababababab".lastIndexOf('a') == 8, 'lastIndexOf')
-ok("a,b,c,d,e".split(',').length == 5, 'split (string)')
+tap.count(8);
+
+tap.ok("1234567890".substring(3, 6) == "456", 'substring 1')
+tap.ok("abc".substring(0, 0) == "", 'substring 2')
+tap.ok("ababababab".indexOf('a') == 0, 'indexOf')
+tap.ok("ababababab".lastIndexOf('a') == 8, 'lastIndexOf')
+tap.ok("a,b,c,d,e".split(',').length == 5, 'split (string)')
 console.log("#", "a,b,c,d,e".split(/,/));
-ok("a,b,c,d,e".split(/,/).length == 5, 'split (regexp)')
-ok("abc".slice(0,0) == "", 'slice 1')
-ok("abc".slice(0,1) == "a", 'slice 2')
+tap.ok("a,b,c,d,e".split(/,/).length == 5, 'split (regexp)')
+tap.ok("abc".slice(0,0) == "", 'slice 1')
+tap.ok("abc".slice(0,1) == "a", 'slice 2')

--- a/test/suite/timers.js
+++ b/test/suite/timers.js
@@ -1,16 +1,15 @@
-/* test rig */ var t = 1, tmax = 2
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
+
+tap.count(5);
 
 setTimeout(function () {
-  ok(this == global, '"this" value in timer is global object');
-  ok(true, 'console.log of global works #TODO');
+  tap.ok(this == global, '"this" value in timer is global object');
+  tap.ok(true, 'console.log of global works #TODO');
   // console.log(this)
 }, 10);
 
 var id = setInterval(function () {
-  ok(false, 'error, interval was not cancelled');
+  tap.ok(false, 'error, interval was not cancelled');
   process.exit(1);
 }, 100)
 clearInterval(id);
@@ -22,13 +21,13 @@ var jk = setInterval(function () {
 	count++;
 	clearInterval(jk);
 	if (count > 1) {
-		ok(false, 'error, interval was not cancelled from inside interval')
+		tap.ok(false, 'error, interval was not cancelled from inside interval')
 		process.exit(1)
 	}
 }, 0)
 
 setImmediate(function (arg1, arg2, arg3) {
-	ok(arg1 != null, 'args passed into callback');
-	ok(arg2 == null, 'null args allowed in callback');
-	ok(arg3 != null, 'null args allowed in callback');
+	tap.ok(arg1 != null, 'args passed into callback');
+	tap.ok(arg2 == null, 'null args allowed in callback');
+	tap.ok(arg3 != null, 'null args allowed in callback');
 }, 5, null, 6)

--- a/test/suite/truthy.js
+++ b/test/suite/truthy.js
@@ -1,23 +1,22 @@
-/* test rig */ var t = 1, tmax = 3
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
 
-ok(!(0) == true, '0 is falsy');
-ok(!(false) == true, 'false is falsy');
-ok(!(undefined) == true, 'undefined is falsy')
-ok(!(nil) == true, 'nil is falsy')
-ok(!('') == true, '"" is falsy');
-ok(!!([]) == true, '[] is truthy');
-ok(!!("0") == true, '\"0\" is truthy');
-ok(!!({}) == true, '{} is truthy');
+tap.count(16);
+
+tap.ok(!(0) == true, '0 is falsy');
+tap.ok(!(false) == true, 'false is falsy');
+tap.ok(!(undefined) == true, 'undefined is falsy')
+tap.ok(!(nil) == true, 'nil is falsy')
+tap.ok(!('') == true, '"" is falsy');
+tap.ok(!!([]) == true, '[] is truthy');
+tap.ok(!!("0") == true, '\"0\" is truthy');
+tap.ok(!!({}) == true, '{} is truthy');
 
 var a;
-a = 0; ok(!(a) == true, '0 is falsy');
-a = false; ok(!(a) == true, 'false is falsy');
-a = undefined; ok(!(a) == true, 'undefined is falsy')
-a = nil; ok(!(a) == true, 'nil is falsy')
-a = ''; ok(!(a) == true, '"" is falsy');
-a = []; ok(!!(a) == true, '[] is truthy');
-a = "0"; ok(!!(a) == true, '\"0\" is truthy');
-a = {}; ok(!!(a) == true, '{} is truthy');
+a = 0; tap.ok(!(a) == true, '0 is falsy');
+a = false; tap.ok(!(a) == true, 'false is falsy');
+a = undefined; tap.ok(!(a) == true, 'undefined is falsy')
+a = nil; tap.ok(!(a) == true, 'nil is falsy')
+a = ''; tap.ok(!(a) == true, '"" is falsy');
+a = []; tap.ok(!!(a) == true, '[] is truthy');
+a = "0"; tap.ok(!!(a) == true, '\"0\" is truthy');
+a = {}; tap.ok(!!(a) == true, '{} is truthy');

--- a/test/suite/try.js
+++ b/test/suite/try.js
@@ -1,28 +1,27 @@
-/* test rig */ var t = 1, tmax = 6
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
+
+tap.count(5);
 
 var e = null;
 try {
 	throw "BOO";
 } catch (e) { }
-ok(e == null, 'error should not escape scope of try #TODO')
+tap.ok(e == null, 'error should not escape scope of try #TODO')
 
 try {
 	try {
 	    throw 'hi';
 	} finally {
-	    console.log('ok');
+	    tap.ok(true);
 	}
 } catch (e) {
-	console.log('ok');
+	tap.ok(true);
 } finally {
-	console.log('ok');
+	tap.ok(true);
 }
 
 var err;
 try {
     throw Error("ERRR");
 } catch (e) { err = e; }
-ok(err, 'error exists');
+tap.ok(err, 'error exists');

--- a/test/suite/url.js
+++ b/test/suite/url.js
@@ -1,3 +1,7 @@
+var tap = require('../tap');
+
+tap.count(14);
+
 var expected = { protocol: 'ws:',
 		 slashes: true,
 		 auth: 'user:pass',
@@ -11,22 +15,15 @@ var expected = { protocol: 'ws:',
 		 path: '/events?q=123',
 		 href: 'ws://user:pass@somedomain.com:1234/events?q=123#hash1' };
 
-
-/* test rig */ var t = 1, tmax = Object.keys(expected).length + 2;
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-function equal (a, b, d) { console.log((a === b) ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+tap.ok(process.versions.colony, 'running in colony')
 
 var url = require('url');
-ok(url.parse('http://tools.ietf.org/html/draft-ietf-6man-text-addr-representation-04#section-6'), 'url parses');
+tap.ok(url.parse('http://tools.ietf.org/html/draft-ietf-6man-text-addr-representation-04#section-6'), 'url parses');
 
 var actual = url.parse('ws://user:pass@somedomain.com:1234/events?q=123#hash1');
 
 Object.keys(expected).forEach(function(k){
-  
-  equal(actual[k], expected[k], k + ' should matched expected ')
+  tap.eq(actual[k], expected[k], k + ' should matched expected ')
 });
 
-ok(url.parse('http://api.openweathermap.org/data/2.5/weather?id=5327684&units=imperial').hostname == 'api.openweathermap.org', 'hostname match');
+tap.ok(url.parse('http://api.openweathermap.org/data/2.5/weather?id=5327684&units=imperial').hostname == 'api.openweathermap.org', 'hostname match');

--- a/test/suite/with.js
+++ b/test/suite/with.js
@@ -1,7 +1,6 @@
-/* test rig */ var t = 1, tmax = 1
-function ok (a, d) { console.log(a ? 'ok ' + (t++) + ' -' : 'not ok ' + (t++) + ' -', d); }
-console.log(t + '..' + tmax);
-ok(process.versions.colony, 'running in colony')
+var tap = require('../tap');
+
+tap.count(7);
 
 var internal = function () {
 	return 'external';
@@ -19,15 +18,15 @@ var obj = {
 
 var a = 5;
 with (obj) {
-	console.log(internal() == 'internal' ? 'ok 1' : 'not ok 1');
-	console.log(external() == 'external' ? 'ok 2' : 'not ok 2');
+	tap.eq(internal(), 'internal')
+	tap.eq(external(), 'external');
 	obj.external = function () {
 		return 'internal';
 	}
-	console.log(external() == 'internal' ? 'ok 3' : 'not ok 3');
+	tap.eq(external(), 'internal');
 	a = 6;
 }
-console.log(a == 6 ? 'ok 4' : 'not ok 4');
+tap.eq(a, 6);
 
 t = 5;
 var a, x, y;
@@ -39,6 +38,6 @@ with (Math) {
   y = r * sin(PI / 2);
 }
 
-ok(a == Math.PI * 100)
-ok(x == -10)
-ok(y == 10)
+tap.eq(a, Math.PI * 100)
+tap.eq(x, -10)
+tap.eq(y, 10)

--- a/test/tap.js
+++ b/test/tap.js
@@ -1,5 +1,10 @@
-function tap (max) { tap.t = 1; console.log(tap.t + '..' + max); };
-tap.count = tap;
-tap.ok = function (a, d) { console.log((a ? '' : 'not ') + 'ok', tap.t++, '-', d); }
+/*
+** Simple tap tester.
+** This should rely on as few features as possible.
+** modules, console.log, fns, string concat, String cast, JSON.stringify, if statements.
+*/
+
+var tap = exports;
+tap.count = function (max) { tap.t = 1; console.log(String(tap.t) + '..' + String(max)); };
+tap.ok = function (a, d) { var not = ''; if (!a) { not = 'not '; } console.log(not + 'ok', tap.t, '-', d); tap.t = tap.t + 1; }
 tap.eq = function (a, b, c) { tap.ok(a == b, String(c) + ': ' + JSON.stringify(String(a)) + ' == ' + JSON.stringify(String(b))); }
-module.exports = tap;


### PR DESCRIPTION
Most tests should now use the "tap" module located at `src/tap.js`. This is a bare-bones tester that encapsulates testing logic without introducing too many failure points for tests. (That is, if you can build a JS runtime that evaluates the `tap.js` script, then you should be able to make use of the tests.)
