### PR TITLE
removes ipv6 check

### DIFF
--- a/src/colony/modules/net.js
+++ b/src/colony/modules/net.js
@@ -26,24 +26,8 @@ function isIPv4 (host) {
   return /^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\.|$)){4}/.test(host);
 }
 
-function isIPv6 (host) {
-  // via http://stackoverflow.com/a/17871737/179583
-  var itIs = /^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]).){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]).){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/.test(host);
-  if (!itIs && typeof host === 'string') {
-    // HACK: regex above doesn't handle all IPv4-suffixed-IPv6 addresses, and, well…do you really blame me for not fixing it?
-    var parts = host.split(':');
-    if (isIPv4(parts[parts.length-1])) {
-      parts.pop();
-      parts.push('FFFF:FFFF');
-      itIs = isIPv6(parts.join(':'));
-    }
-  }
-  return itIs;
-}
-
 function isIP (host) {
-  if (isIPv6(host)) return 6;
-  else if (isIPv4(host)) return 4;
+  if (isIPv4(host)) return 4;
   else return 0;
 }
 
@@ -533,7 +517,6 @@ function createServer (opts, onsocket) {
 
 exports.isIP = isIP;
 exports.isIPv4 = isIPv4;
-exports.isIPv6 = isIPv6;
 exports.connect = exports.createConnection = connect;
 exports.createServer = createServer;
 exports.Socket = TCPSocket;

--- a/test/suite/net.js
+++ b/test/suite/net.js
@@ -6,7 +6,7 @@ test('addresses', function (t) {
   // API checks
   t.ok(net.isIP);
   t.ok(net.isIPv4);
-  t.ok(net.isIPv6);
+  // t.ok(net.isIPv6);
   
   // some samples from http://publib.boulder.ibm.com/infocenter/ts3500tl/v1r0/index.jsp?topic=%2Fcom.ibm.storage.ts3500.doc%2Fopg_3584_IPv4_IPv6_addresses.html
   // c.f. http://tools.ietf.org/id/draft-main-ipaddr-text-rep-02.txt for some grammar discussion
@@ -28,9 +28,10 @@ test('addresses', function (t) {
   validIPv4.forEach(function (v) {
     t.equal(net.isIP(v), 4, v);
   });
-  validIPv6.forEach(function (v) {
-    t.equal(net.isIP(v), 6, v);
-  });
+  // isIP only for ipv4 right now
+  // validIPv6.forEach(function (v) {
+  //   t.equal(net.isIP(v), 6, v);
+  // });
   totalBunk.forEach(function (v) {
     t.equal(net.isIP(v), 0, v);
   });
@@ -46,16 +47,16 @@ test('addresses', function (t) {
     t.equal(net.isIPv4(v), false, v);
   });
   
-  // isIPv6
-  validIPv4.forEach(function (v) {
-    t.equal(net.isIPv6(v), false, v);
-  });
-  validIPv6.forEach(function (v) {
-    t.equal(net.isIPv6(v), true, v);
-  });
-  totalBunk.forEach(function (v) {
-    t.equal(net.isIPv6(v), false, v);
-  });
+  // // isIPv6
+  // validIPv4.forEach(function (v) {
+  //   t.equal(net.isIPv6(v), false, v);
+  // });
+  // validIPv6.forEach(function (v) {
+  //   t.equal(net.isIPv6(v), true, v);
+  // });
+  // totalBunk.forEach(function (v) {
+  //   t.equal(net.isIPv6(v), false, v);
+  // });
   
   t.end();
 });


### PR DESCRIPTION
CC3k does not support IPv6. This significantly speeds up net.js
