### PR TITLE
bump backlog up to 5

### DIFF
--- a/src/posix/tm_net.c
+++ b/src/posix/tm_net.c
@@ -186,7 +186,7 @@ int tm_tcp_listen (tm_socket_t sock, uint16_t port)
   }
 
   // TM_DEBUG("Listening on local socket...");
-  int listenStatus = listen(sock, 1);
+  int listenStatus = listen(sock, 5);
   if (listenStatus != 0) {
     // TM_COMMAND('w', "cannot listen to socket: %d", listenStatus);
     // CC3000_END;


### PR DESCRIPTION
fixes https://github.com/tessel/runtime/issues/441

Apparently [this](http://www.freebsd.org/doc/en_US.ISO8859-1/books/handbook/configtuning-kernel-limits.html) says that it should be 128 but that seems high and unlikely to be able to be supported by actual hardware. 

Thoughts @natevw?
