### PR TITLE
Fix String.match() with non-regex parameter, add Regex.exec result properties

### DIFF
--- a/src/colony/lua/colony-js.lua
+++ b/src/colony/lua/colony-js.lua
@@ -1757,12 +1757,11 @@ if type(hs) == 'table' then
     end
   end
 
-  global.RegExp.prototype.exec = function (regex, subj)
-    -- TODO wrong
-    local cre = getmetatable(regex).cre
-    local crestr = getmetatable(regex).crestr
+  global.RegExp.prototype.exec = function (this, subj)
+    local cre = getmetatable(this).cre
+    local crestr = getmetatable(this).crestr
     if type(cre) ~= 'userdata' then
-      error(js_new(global.TypeError, 'Cannot call RegExp.prototype.match on non-regex'))
+      error(js_new(global.TypeError, 'Cannot call RegExp.prototype.exec on non-regex'))
     end
 
     local data = tostring(subj)
@@ -1771,7 +1770,7 @@ if type(hs) == 'table' then
       return nil
     end
     local ret, len = {}, 0
-    for i=0,hs.regex_nsub(cre) do
+    for i=0, hs.regex_nsub(cre) do
       local so, eo = hs.regmatch_so(hsmatch, i), hs.regmatch_eo(hsmatch, i)
       if so == -1 or eo == -1 then
         table.insert(ret, len, nil)
@@ -1780,6 +1779,10 @@ if type(hs) == 'table' then
       end
       len = len + 1
     end
+
+    ret.index = hs.regmatch_so(hsmatch, 0)
+    ret.input = data
+
     return js_arr(ret, len)
   end
 

--- a/test/suite/regex.js
+++ b/test/suite/regex.js
@@ -1,6 +1,6 @@
 var tap = require('../tap');
 
-tap.count(13);
+tap.count(17);
 
 tap.ok("garbage 09 _ - !@#$%".match(/^[\s\S]+$/), 'regex match');
 
@@ -42,6 +42,11 @@ tap.ok(subj1.match(b), 'matches numbers and whitespace');
 
 var c = /cav[ea]+t/i;
 tap.ok(subj2.match(c)[0] == 'caveaaAEEAAEeaeaEAEaeeaEEAEEAet', 'matches char classes');
+
+tap.ok(subj1.match('99'), 'matches non-regex values');
+tap.ok(a.exec(subj1).index == 10, 'exec with index attribute');
+tap.ok(a.exec(subj1).input == subj1, 'exec with input attribute');
+tap.ok(b.exec(subj1).index == 10, 'exec with index attribute and submatch');
 
 tap.ok(c.test(subj2), 'test() works')
 


### PR DESCRIPTION
Cleanup of @micnic's #485. Fixes #482
