### PR TITLE
freeing regexes

### DIFF
--- a/src/colony/lua_hsregex.c
+++ b/src/colony/lua_hsregex.c
@@ -125,6 +125,8 @@ static int l_re_exec (lua_State* L)
   size_t data_len;
   chr* data = toregexstr(input, input_len, &data_len);
   int rc = re_exec(cre, data, data_len, NULL, pmatchlen, pmatch, flags);
+  
+  free(data);
   lua_pushnumber(L, rc);
   return 1;
 }


### PR DESCRIPTION
This PR addresses two places in which we never free regex structs after hsregex callocs them.
