### PR TITLE
Fixes Array.prototype.shift to not remove 0 at index 1. Fixes #472

### DIFF
--- a/src/colony/lua/colony-js.lua
+++ b/src/colony/lua/colony-js.lua
@@ -408,7 +408,11 @@ arr_proto.shift = function (this)
   local len = tonumber(rawget(this, 'length'))
   local ret = rawget(this, 0)
   if len > 0 then
-    rawset(this, 0, table.remove(this, 1) or nil)
+    if len > 1 then
+      rawset(this, 0, table.remove(this, 1))
+    else
+      rawset(this, 0, nil)
+    end
     rawset(this, 'length', len - 1)
   end
   return ret

--- a/test/issues/issue-runtime-472.js
+++ b/test/issues/issue-runtime-472.js
@@ -1,0 +1,25 @@
+var tap = require('../tap')
+
+tap.count(5)
+
+var arr = [1, 2, 3, 4, 5];
+
+var compare = [
+	[0,3,4,5],
+	[1,0,4,5],
+	[1,2,0,5],
+	[1,2,3,0],
+]
+
+arr.forEach(function(val, index){
+  if (index+1 < arr.length) {
+    var newArr =  JSON.parse(JSON.stringify(arr));
+    newArr[index+1] = 0;
+    newArr.splice(index, 1);
+    tap.eq(newArr.join(','), compare[index].join(','), 'array splice iteration ' + index);
+  }
+});
+
+var arr2 = [1, 0, 2, 3]
+arr2.shift();
+tap.eq(arr2.join(','), '0,2,3', 'array shift works with leading 0 index')


### PR DESCRIPTION
This was actually an issue with Array.prototype.shift, not Array.prototype.splice, but alas.
