### PR TITLE
Slow http writes during HW busy times

### DIFF
--- a/src/colony/modules/http.js
+++ b/src/colony/modules/http.js
@@ -263,13 +263,18 @@ function OutgoingMessage () {
   
   var self = this;
   this.once('finish', function () {
-    if (self._socket && self._socket._destroy !== true) {
+    // Workaround for us being slow on socket writes/having to deal with HW interrupts.
+    // If we do have a socket, make sure that the socket stream hasn't ended.
+    // Otherwise we try to write the ending chunks after we already have a response
+    // and the socket has been closed.
+    if (self._socket == null 
+      || (self._socket && self._socket._destroy !== true)) {
       if (!self.headersSent) {
         self._chunked = false;
         self.flush();
       }
-      if (this._chunked) {
-        self._outbox.write('0\r\n'+this._trailer+'\r\n');
+      if (self._chunked) {
+        self._outbox.write('0\r\n'+self._trailer+'\r\n');
       }
     }
   });

--- a/src/colony/modules/net.js
+++ b/src/colony/modules/net.js
@@ -494,6 +494,8 @@ TCPSocket.prototype.__close = function (tryToClose) {
 }
 
 TCPSocket.prototype.destroy = TCPSocket.prototype.close = function () {
+  this._destroy = true;
+  
   var self = this;
   setImmediate(function () {
     if (self.__listenid != null) {


### PR DESCRIPTION
We can run into issues like this when we have HW interrupts messing with our timing:

```
// us writing
writing POST /photo HTTP/1.1
Host: 192.168.128.250:3000
Transfer-Encoding: chunked


4

test

// note that right here we're supposed to have a 0\r\n\n
// however we only do that once the 'finish' event is called on the socket. 
// my guess is that we don't do this here because Tessel is busy with HW things from a camera

// got this response from the express server
HTTP/1.1 200 OK
X-Powered-By: Express
Content-Type: text/html; charset=utf-8
Content-Length: 7
Date: Fri, 03 Oct 2014 07:44:08 GMT
Connection: keep-alive

done

// right now the socket is closed
// but we finally catch the 'finish' event
// without this PR we would try to write 0\r\n\n here and get a writable stream error
```

Technically this problem can also be circumvented if people wait for the 'end' event on the request before sending a response, but I think very few people are going to do that.
