### PR TITLE
Disables spinner on Travis.

### DIFF
--- a/.travis.arm.yml
+++ b/.travis.arm.yml
@@ -9,6 +9,7 @@ before_install:
   - brew install node || true
   - git config credential.helper store
   - git clone https://github.com/tessel/colony-lua.git deps/colony-lua
+  - npm config set spin=false
 install:
   - git submodule update --init
   - npm install

--- a/.travis.linux.yml
+++ b/.travis.linux.yml
@@ -16,6 +16,7 @@ before_install:
   - popd
   - git config credential.helper store
   - git clone https://github.com/tessel/colony-lua.git deps/colony-lua
+  - npm config set spin=false
 install:
   - git submodule update --init
   - npm install

--- a/.travis.osx.yml
+++ b/.travis.osx.yml
@@ -9,6 +9,7 @@ before_install:
   - brew install node || true
   - git config credential.helper store
   - git clone https://github.com/tessel/colony-lua.git deps/colony-lua
+  - npm config set spin=false
 install:
   - git submodule update --init
   - npm install


### PR DESCRIPTION
New npm builds add a spinner in `npm test` which clutters up the log output.
