### PR TITLE
Requires string splitting to return empty string. Fixes #534

### DIFF
--- a/src/colony/lua/colony-js.lua
+++ b/src/colony/lua/colony-js.lua
@@ -231,7 +231,7 @@ str_proto.split = function (str, sep, max)
   local i = 0
   if str_regex_split and js_instanceof(sep, global.RegExp) then
     return str_regex_split(str, sep, max)
-  elseif type(sep) == 'string' and string.len(str) > 0 then
+  elseif type(sep) == 'string' then
     max = max or -1
 
     local start=1

--- a/src/colony/lua_hsregex.c
+++ b/src/colony/lua_hsregex.c
@@ -339,7 +339,7 @@ static int l_regex_split (lua_State *L)
   lua_createtable(L, 0, 0);
 
   int idx = 0;
-  while (w_input_len > 0) {
+  while (w_input_len > 0 || idx == 0) {
     int rc = re_exec(cre, w_input, w_input_len, NULL, pmatch_len, pmatch, 0);
     if (rc != 0) {
       lua_pushlstring(L, input, input_len);

--- a/test/issues/issue-runtime-534.js
+++ b/test/issues/issue-runtime-534.js
@@ -1,0 +1,15 @@
+var tap = require('../tap');
+
+tap.count(2);
+
+var split1 = ''.split('.');
+tap.eq(typeof split1[0], 'string', 'split empty string (with string) returns [""]');
+
+var split2 = ''.split(/ *; */);
+tap.eq(typeof split2[0], 'string', 'split empty string (with regex) returns [""]');
+
+var split3 = 'apple'.split('.');
+tap.eq(split3[0], 'apple', 'split "apple" (with string) returns ["apple"]');
+
+var split4 = 'apple'.split(/ *; */);
+tap.eq(split4[0], 'apple', 'split "apple" (with regex) returns ["apple"]');


### PR DESCRIPTION
See testcase for example.
