### PR TITLE
Ensure "make test-node" runs against Node 0.10.30+

### DIFF
--- a/.travis.linux.yml
+++ b/.travis.linux.yml
@@ -23,7 +23,7 @@ install:
   - sudo apt-get -y install gyp
 script:
   - make colony
-  - npm test
+  - make test
 
 git:
   submodules: false

--- a/.travis.osx.yml
+++ b/.travis.osx.yml
@@ -15,7 +15,7 @@ install:
   - make update
 script:
   - make colony
-  - npm test
+  - make test
 
 git:
   submodules: false

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ test-colony:
 
 test-node:
 	@echo "node testbench:"
+	@node -p '"(testing against node " + process.versions.node + ")"'
+	@node -e "process.exit(process.versions.node.match(/^0\.10\.[3]/)?0:1)" || (echo "please test with node >=0.10.30" && exit 1)
 	@./node_modules/.bin/tap -e node test/suite/*.js test/issues/*.js test/net/*.js
 
 update-node-libs:


### PR DESCRIPTION
See #554. Nave is a userland way of switching between Node versions (think rvm). Targeting a specific Node version would help an eventual transition to any other version, and pin our tests against a specific API and its bugs.

Downsides: if Nave isn't permitted to cache Node versions in the manner it wants, it will re-download the Node binary each time the test is run.
