### PR TITLE
Removes unused "preload_on_init" option.

### DIFF
--- a/src/colony/colony_runtime.c
+++ b/src/colony/colony_runtime.c
@@ -249,15 +249,6 @@ int colony_runtime_open ()
   // Initialize runtime semantics.
   colony_init(L);
 
-  // Load all builtin libraries immediately on init.
-  // This can trade loss of sped for later access.
-#ifdef COLONY_PRELOAD
-  lua_pushnumber(L, 1);
-#else
-  lua_pushnumber(L, 0);
-#endif
-  lua_setglobal(L, "_colony_preload_on_init");
-
   return tm_eval_lua(L, "require('preload');");
 }
 

--- a/src/colony/lua/preload.lua
+++ b/src/colony/lua/preload.lua
@@ -60,12 +60,7 @@ for k, v in pairs(_builtin) do
     end
   end)(k, v)
 end
-if _colony_preload_on_init then
-  for k, v in pairs(_builtin) do
-    -- preload all the things
-    colony.run(k)
-  end
-end
+
 collectgarbage()
 
 if _G.COLONY_EMBED then


### PR DESCRIPTION
This is broken on master, since process is instantiated **after** libs are preloaded, anyway.
