### PR TITLE
Allows iterators to iterate inherited properties from prototype.

### DIFF
--- a/test/issues/issue-runtime-487.js
+++ b/test/issues/issue-runtime-487.js
@@ -1,0 +1,19 @@
+var tap = require('../tap');
+
+tap.count(1);
+
+var Test = function Test() {
+  this.alpha = "hi";
+  this.bravo = 1;
+  this.charlie = ["hello", "there"]
+  this.delta = function() {};
+};
+
+Test.prototype.echo = function echo() {};
+
+var t = new Test(),
+    opts = [];
+
+for (var opt in t) { opts.push(opt); }
+
+tap.ok(opts.indexOf('echo') > -1, 'function iterator carries enumerable properties from prototype');


### PR DESCRIPTION
Fixes #487.

This change is a hack to basically iterate up the prototype chain until we hit an internal prototype, like Object/String/Array/etc. This passes all tests and meets the common usecase of iterating property methods without adding more keys into the mix. This will tide over until #591 is fixed.
