### PR TITLE
remove hardcoded dns

### DIFF
--- a/src/colony/lua_cares.c
+++ b/src/colony/lua_cares.c
@@ -15,6 +15,7 @@
 #include <sys/time.h>
 #include <unistd.h>
 #include <ares.h>
+#include <tm.h>
 #ifndef COLONY_EMBED
 #include <arpa/inet.h>
 #include <netinet/in.h>
@@ -89,7 +90,7 @@ wait_ares(ares_channel channel)
         ares_process(channel, &read_fds, &write_fds);
     }
 }
- 
+
 // Bad synchronous gethostbyname demo
 uint32_t tm__sync_gethostbyname (const char *domain)
 {
@@ -102,7 +103,12 @@ uint32_t tm__sync_gethostbyname (const char *domain)
 
     struct in_addr ns1;
 
-    inet_aton("8.8.8.8",&ns1);
+    // get the dns server
+    uint32_t ip_dns = tm_net_dnsserver();
+    char str_dns[16] = {0};
+    sprintf(str_dns, "%d.%d.%d.%d", (int)GET_BYTE(ip_dns, 3), (int)GET_BYTE(ip_dns, 2), (int)GET_BYTE(ip_dns, 1), (int)GET_BYTE(ip_dns, 0));
+    
+    inet_aton(str_dns, &ns1);
  
     status = ares_library_init(ARES_LIB_INIT_ALL);
     if (status != ARES_SUCCESS){

--- a/src/colony/lua_cares.c
+++ b/src/colony/lua_cares.c
@@ -105,8 +105,12 @@ uint32_t tm__sync_gethostbyname (const char *domain)
 
     // get the dns server
     uint32_t ip_dns = tm_net_dnsserver();
-    char str_dns[16] = {0};
-    sprintf(str_dns, "%d.%d.%d.%d", (int)GET_BYTE(ip_dns, 3), (int)GET_BYTE(ip_dns, 2), (int)GET_BYTE(ip_dns, 1), (int)GET_BYTE(ip_dns, 0));
+    if (ip_dns == 0) {
+        // error not connected
+        return 1;
+    }
+    char str_dns[16] = {0}; // length of 255.255.255.255 + 1
+    sprintf(str_dns, "%d.%d.%d.%d", (uint8_t)TM_BYTE(ip_dns, 3), (uint8_t)TM_BYTE(ip_dns, 2), (uint8_t)TM_BYTE(ip_dns, 1), (uint8_t)TM_BYTE(ip_dns, 0));
     
     inet_aton(str_dns, &ns1);
  

--- a/src/posix/tm_net.c
+++ b/src/posix/tm_net.c
@@ -137,7 +137,7 @@ int tm_tcp_connect (tm_socket_t sock, uint32_t addr, uint16_t port)
 
 uint32_t tm_net_dnsserver () {
   // for now just do 8.8.8.8 on the PC
-  return 134744072;
+  return 0x08080808;
 }
 
 // http://publib.boulder.ibm.com/infocenter/iseries/v5r3/index.jsp?topic=%2Frzab6%2Frzab6xnonblock.htm

--- a/src/posix/tm_net.c
+++ b/src/posix/tm_net.c
@@ -135,6 +135,11 @@ int tm_tcp_connect (tm_socket_t sock, uint32_t addr, uint16_t port)
     return connect(sock, (struct sockaddr *) &server, sizeof(server));
 }
 
+uint32_t tm_net_dnsserver () {
+  // for now just do 8.8.8.8 on the PC
+  return 134744072;
+}
+
 // http://publib.boulder.ibm.com/infocenter/iseries/v5r3/index.jsp?topic=%2Frzab6%2Frzab6xnonblock.htm
 
 int tm_tcp_write (tm_socket_t sock, const uint8_t *buf, size_t buflen)

--- a/src/tm.h
+++ b/src/tm.h
@@ -23,6 +23,8 @@ extern "C" {
 #include <time.h>
 #include <stdbool.h>
 
+#define GET_BYTE(A, B) ((A >> (B*8)) & 0xFF)
+
 // logging
 void tm_log(char level, const char* string, unsigned length);
 void tm_logf(char level, const char* format, ...);
@@ -136,6 +138,7 @@ tm_socket_t tm_tcp_accept (tm_socket_t sock, uint32_t *addr, uint16_t *port);
 // DNS
 
 uint32_t tm_hostname_lookup (const uint8_t *hostname);
+uint32_t tm_net_dnsserver();
 
 // Random
 

--- a/src/tm.h
+++ b/src/tm.h
@@ -23,7 +23,7 @@ extern "C" {
 #include <time.h>
 #include <stdbool.h>
 
-#define GET_BYTE(A, B) ((A >> (B*8)) & 0xFF)
+#define TM_BYTE(A, B) ((A >> (B*8)) & 0xFF)
 
 // logging
 void tm_log(char level, const char* string, unsigned length);


### PR DESCRIPTION
goes with https://github.com/tessel/firmware/pull/101

Changes DNS from 8.8.8.8 to whatever Tessel picks up. 

On PC colony it still defaults to 8.8.8.8.
