### PR TITLE
match undocumented http.Agent inheritance, fixes #603

### DIFF
--- a/src/colony/modules/http.js
+++ b/src/colony/modules/http.js
@@ -378,8 +378,9 @@ function Agent (opts) {
   this.freeSockets = {};
   this.requests = {};
   this._pools = {};
-  
 }
+
+util.inherits(Agent, EventEmitter);
 
 Agent.prototype.destroy = function () {
   Object.keys(this._pools).forEach(function (k) {


### PR DESCRIPTION
This doesn't completely match the API that agentkeepalive thinks will be there, but AFAICT its use of those is only for a) collecting stats, and b) setting some socket options that our TCP implementation doesn't really support anyway.
