### PR TITLE
Build runtime with colonyjit (interpreter).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ else
 		ninja -C out/$(CONFIG)
 endif
 
-.PHONY: all test test-colony test-node luajit-check
+.PHONY: all test test-colony test-node prepare-pc prepare-arm
 
 all: colony
 
@@ -52,16 +52,20 @@ update-node-libs:
 	mkdir -p deps/node-libs
 	cd deps/node-libs; curl -L https://github.com/joyent/node/archive/v$(NODE_VERSION).tar.gz | tar xvf - --strip-components=2 node-$(NODE_VERSION)/lib
 
-luajit-check:
-	objdump -G deps/colony-luajit/src/libluajit.a > /dev/null || make -C deps/colony-luajit clean || true
-	touch deps/colony-luajit/Makefile
+prepare-pc:
+	@objdump -G deps/colony-luajit/src/libluajit.a >/dev/null 2>&1 || make -C deps/colony-luajit clean || true
+	@touch deps/colony-luajit/Makefile
+
+prepare-arm:
+	@arm-none-eabi-objdump -G deps/colony-luajit/src/libluajit.a >/dev/null 2>&1 || make -C deps/colony-luajit clean || true
+	@touch deps/colony-luajit/Makefile
 
 # Targets
 
 libcolony:
 	$(call compile, libcolony.gyp)
 
-colony: luajit-check
+colony: prepare-pc
 	$(call compile, colony.gyp)
 
 libtm-test:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ENABLE_TLS ?= 1
 ENABLE_NET ?= 1
-ENABLE_LUAJIT ?= 0
+ENABLE_LUAJIT ?= 1
 
 # Update when targeting new Node build.
 NODE_VERSION ?= 0.10.32

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ else
 		ninja -C out/$(CONFIG)
 endif
 
-.PHONY: all test test-colony test-node
+.PHONY: all test test-colony test-node luajit-check
 
 all: colony
 
@@ -52,13 +52,16 @@ update-node-libs:
 	mkdir -p deps/node-libs
 	cd deps/node-libs; curl -L https://github.com/joyent/node/archive/v$(NODE_VERSION).tar.gz | tar xvf - --strip-components=2 node-$(NODE_VERSION)/lib
 
+luajit-check:
+	objdump -G deps/colony-luajit/src/libluajit.a > /dev/null || make -C deps/colony-luajit clean || true
+	touch deps/colony-luajit/Makefile
+
 # Targets
 
 libcolony:
 	$(call compile, libcolony.gyp)
 
-colony:
-	touch deps/colony-luajit/Makefile || true
+colony: luajit-check
 	$(call compile, colony.gyp)
 
 libtm-test:

--- a/libcolony.gyp
+++ b/libcolony.gyp
@@ -211,6 +211,7 @@
         'src/colony/colony.c',
         'src/colony/colony_init.c',
         'src/colony/colony_runtime.c',
+        'src/colony/lua_http_parser.c',
         '<(SHARED_INTERMEDIATE_DIR)/dir_builtin.c',
         '<(SHARED_INTERMEDIATE_DIR)/dir_runtime_lib.c',
       ],
@@ -226,7 +227,8 @@
         'libtm.gyp:fortuna',
         'libtm.gyp:dlmalloc',
         'libtm.gyp:libtm',
-        'libtm.gyp:approxidate'
+        'libtm.gyp:approxidate',
+        'libtm.gyp:http_parser',
       ],
       "direct_dependent_settings": {
         "include_dirs": [
@@ -264,11 +266,9 @@
         ['enable_net==1', {
           'sources': [
             'src/colony/lua_cares.c',
-            'src/colony/lua_http_parser.c',
           ],
           'dependencies': [
             'libtm.gyp:c-ares',
-            'libtm.gyp:http_parser',
           ],
         }],
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runtime",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "private": true,
   "bin": {
     "colony": "./out/Release/colony",
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "async": "~0.2.9",
-    "colony-compiler": "~0.6.22",
+    "colony-compiler": "~0.6.23",
     "mkdirp": "~0.3.5",
     "bindings": "~1.2.0"
   },

--- a/src/colony/colony_runtime.c
+++ b/src/colony/colony_runtime.c
@@ -218,11 +218,9 @@ int colony_runtime_open ()
   // tm
   lua_pushcfunction(L, luaopen_tm);
   lua_setfield(L, -2, "tm");
-#ifdef ENABLE_NET
   // http_parser
   lua_pushcfunction(L, luaopen_http_parser);
   lua_setfield(L, -2, "http_parser_lua");
-#endif
   // hsregex
   lua_pushcfunction(L, luaopen_hsregex);
   lua_setfield(L, -2, "hsregex");

--- a/src/colony/lua/colony-node.lua
+++ b/src/colony/lua/colony-node.lua
@@ -836,7 +836,17 @@ local function require_load (p)
           module.exports = parsed
         end
       else
-        res = assert(loadstring(colony._load(p), "@"..p))()
+        local fn, err, c = loadstring(colony._load(p), "@"..p)
+        if err and string.find(tostring(err), 'incompatible bytecode') then
+          res = function ()
+            console:error('! Error: Outdated CLI')
+            console:error('! Please update your Tessel CLI using npm to run code on this board.')
+            console:error('! Run "npm install -g tessel" or see http://start.tessel.io/')
+            process:exit(127)
+          end
+        else
+          res = assert(fn, err)()
+        end
       end
     end
   end

--- a/src/colony/lua/preload.lua
+++ b/src/colony/lua/preload.lua
@@ -81,7 +81,7 @@ if not _G.COLONY_EMBED then
     if jit == nil then
       status = os.execute(_G.COLONY_COMPILER_PATH .. ' -m ' .. file .. ' > /tmp/colonyunique')
     else
-      status = os.execute(_G.COLONY_COMPILER_PATH .. ' ' .. file .. ' > /tmp/colonyunique')
+      status = os.execute(_G.COLONY_COMPILER_PATH .. ' -l ' .. file .. ' > /tmp/colonyunique')
     end
     if status ~= 0 then
       os.exit(status)

--- a/src/colony/lua_tm.c
+++ b/src/colony/lua_tm.c
@@ -525,16 +525,16 @@ static int l_tm_buffer_get (lua_State *L)
 #define TO_16(a, b) ((a << 8) | b)
 #define TO_32(a, b, c, d) ((a << 24) | (b << 16) | (c << 8) | d)
 
-#define WRITE_BUFFER(N, T) static int N (lua_State *L) \
+#define WRITE_BUFFER(N, T, C) static int N (lua_State *L) \
 { \
   uint8_t *ud = (uint8_t *) lua_touserdata(L, 1); \
   size_t index = (size_t) lua_tonumber(L, 2); \
-  int32_t value = lua_type(L, 3) == LUA_TNUMBER \
-    ? (int32_t) lua_tonumber(L, 3) \
-    : lua_type(L, 3) == LUA_TBOOLEAN ? (int32_t) lua_toboolean(L, 3) \
+  T value = lua_type(L, 3) == LUA_TNUMBER \
+    ? (T) lua_tonumber(L, 3) \
+    : lua_type(L, 3) == LUA_TBOOLEAN ? (T) lua_toboolean(L, 3) \
     : lua_type(L, 3) == LUA_TNIL ? 0 : 1; \
   uint8_t *a = &ud[index]; \
-  T; \
+  C; \
   return 0; \
 }
 
@@ -553,16 +553,16 @@ READ_BUFFER(l_tm_buffer_read_int16be, (int16_t) TO_16(a[0], a[1]));
 READ_BUFFER(l_tm_buffer_read_int32le, (int32_t) TO_32(a[3], a[2], a[1], a[0]));
 READ_BUFFER(l_tm_buffer_read_int32be, (int32_t) TO_32(a[0], a[1], a[2], a[3]));
 
-WRITE_BUFFER(l_tm_buffer_write_uint8, WRITE_8((uint8_t) value, a[0]));
-WRITE_BUFFER(l_tm_buffer_write_uint16le, WRITE_16((uint16_t) value, a[1], a[0]));
-WRITE_BUFFER(l_tm_buffer_write_uint16be, WRITE_16((uint16_t) value, a[0], a[1]));
-WRITE_BUFFER(l_tm_buffer_write_uint32le, WRITE_32((uint32_t) value, a[3], a[2], a[1], a[0]));
-WRITE_BUFFER(l_tm_buffer_write_uint32be, WRITE_32((uint32_t) value, a[0], a[1], a[2], a[3]));
-WRITE_BUFFER(l_tm_buffer_write_int8, WRITE_8((int8_t) value, a[0]));
-WRITE_BUFFER(l_tm_buffer_write_int16le, WRITE_16((int16_t) value, a[1], a[0]));
-WRITE_BUFFER(l_tm_buffer_write_int16be, WRITE_16((int16_t) value, a[0], a[1]));
-WRITE_BUFFER(l_tm_buffer_write_int32le, WRITE_32((int32_t) value, a[3], a[2], a[1], a[0]));
-WRITE_BUFFER(l_tm_buffer_write_int32be, WRITE_32((int32_t) value, a[0], a[1], a[2], a[3]));
+WRITE_BUFFER(l_tm_buffer_write_uint8, uint8_t, WRITE_8(value, a[0]));
+WRITE_BUFFER(l_tm_buffer_write_uint16le, uint16_t, WRITE_16(value, a[1], a[0]));
+WRITE_BUFFER(l_tm_buffer_write_uint16be, uint16_t, WRITE_16(value, a[0], a[1]));
+WRITE_BUFFER(l_tm_buffer_write_uint32le, uint32_t, WRITE_32(value, a[3], a[2], a[1], a[0]));
+WRITE_BUFFER(l_tm_buffer_write_uint32be, uint32_t, WRITE_32(value, a[0], a[1], a[2], a[3]));
+WRITE_BUFFER(l_tm_buffer_write_int8, int8_t, WRITE_8(value, a[0]));
+WRITE_BUFFER(l_tm_buffer_write_int16le, int16_t, WRITE_16(value, a[1], a[0]));
+WRITE_BUFFER(l_tm_buffer_write_int16be, int16_t, WRITE_16(value, a[0], a[1]));
+WRITE_BUFFER(l_tm_buffer_write_int32le, int32_t, WRITE_32(value, a[3], a[2], a[1], a[0]));
+WRITE_BUFFER(l_tm_buffer_write_int32be, int32_t, WRITE_32(value, a[0], a[1], a[2], a[3]));
 
 static int l_tm_buffer_read_float (lua_State *L)
 {

--- a/src/colony/lua_tm.c
+++ b/src/colony/lua_tm.c
@@ -529,9 +529,9 @@ static int l_tm_buffer_get (lua_State *L)
 { \
   uint8_t *ud = (uint8_t *) lua_touserdata(L, 1); \
   size_t index = (size_t) lua_tonumber(L, 2); \
-  uint32_t value = lua_type(L, 3) == LUA_TNUMBER \
-    ? (uint32_t) lua_tonumber(L, 3) \
-    : lua_type(L, 3) == LUA_TBOOLEAN ? (uint32_t) lua_toboolean(L, 3) \
+  int32_t value = lua_type(L, 3) == LUA_TNUMBER \
+    ? (int32_t) lua_tonumber(L, 3) \
+    : lua_type(L, 3) == LUA_TBOOLEAN ? (int32_t) lua_toboolean(L, 3) \
     : lua_type(L, 3) == LUA_TNIL ? 0 : 1; \
   uint8_t *a = &ud[index]; \
   T; \

--- a/test/colony/issue-runtime-620.js
+++ b/test/colony/issue-runtime-620.js
@@ -1,0 +1,4 @@
+var tap = require('../tap');
+tap.count(1)
+global._G.collectgarbage.call('collect')
+tap.ok(true, 'collectgarbage call through JS succeeded.')

--- a/tools/compile_folder.sh
+++ b/tools/compile_folder.sh
@@ -31,7 +31,9 @@ packageFolder(infiles, varname, function (file, buf, next) {
       if (docompile) {
         colonyCompiler.toBytecode(colonyCompiler.colonize(String(buf)), '[T]:' + file, next);
       } else {
-        next(null, colonyCompiler.colonize(String(buf)).source);
+        next(null, colonyCompiler.colonize(String(buf), {
+          embedLineNumbers: true
+        }).source);
       }
     } catch (e) {
       throw new Error('Bytecode compilation of ' + file + ' failed.');


### PR DESCRIPTION
Broken out into several commits below, this is the fullness of this PR:
- Adds an invalid bytecode warning suggesting you update your CLI (please read over error text).
- Sets the version number of runtime to "1.0.0" (bold!)
- Updates colony-compiler to support line number embedding and compilation of internal files.
- Makes "http_parser_lua" compiled in regardless of ENABLE_NET, to allow more test coverage in rigs.
- Adds Makefile check for correct target architecture to allow switching betweeen firmware and PC builds seamlessly.
- Fixes Buffer handling on Thumb which was probably always broken.
