### PR TITLE
Corrects newly added timers to not invoke early.

### DIFF
--- a/src/tm_timer.c
+++ b/src/tm_timer.c
@@ -34,6 +34,7 @@ typedef struct tm_timer {
   unsigned repeat; // If nonzero, `time` is reset to `repeat` when the timer expires.
                    // Note that this means setInterval calls are clamped to 1ms
   int lua_cb; // Callback index in the lua registry
+  int pending; // Pending flag for this next loop.
 } tm_timer;
 
 /// Head of the linked list of timers. Pointer to the timeout object which
@@ -94,6 +95,7 @@ unsigned tm_settimeout(unsigned time, bool repeat, int lua_cb) {
 	t->lua_cb = lua_cb;
 	t->next = 0;
 	t->id = ++timer_id;
+	t->pending = 0;
 
 	if (!timers_head) {
 		last_time = tm_uptime_micro();
@@ -155,8 +157,15 @@ void timer_cb(tm_event* event) {
 	last_time = tm_uptime_micro();
 	unsigned elapsed = last_time - prev_time;
 
-	while (timers_head) {
-		tm_timer* t = timers_head;
+	// Mark all timers as "pending" for this loop.
+	tm_timer* t = timers_head;
+	while (t) {
+		t->pending = 1;
+		t = t->next;
+	}
+
+	while (timers_head && timers_head->pending) {
+		t = timers_head;
 
 		if (t->time > elapsed) {
 			t->time -= elapsed;


### PR DESCRIPTION
Timers can enter a race condition where if they are added, and the "elapsed" variable is sufficiently large, then it will consider the newly added timer as being invoked immediately.

```
INFO Bundling directory /Users/tim/Code/technical/workspace/firmware/test
INFO Deploying bundle (1.65 MB)...
INFO Running script...
~~~> time 0 elapsed 176
~~~> time 0 elapsed 176
TAP version 13
~~~> time 29812 elapsed 176
~~~> time 29636 elapsed 1990166 (!!!)
# small async transfer
ADD NEW 1S TIMER
~~~> time 1000000 elapsed 1960530 (!!!)
--> failed at [ 0, 274179072 ]
--> failed at :  0 0.073485824
not ok 1 test timed out
  ---
    operator: fail
  ...
```

See that the "ADD NEW 1S TIMER" is evaluated using the elapsed time that was sampled at the beginning of the loop it is inside. (The difference in elapsed time is due to elapsed time being subtracted by the counter to keep ordering consistent)
