### PR TITLE
Supports function parameter names in Function.toString().

### DIFF
--- a/src/colony/lua/colony-js.lua
+++ b/src/colony/lua/colony-js.lua
@@ -381,7 +381,12 @@ func_proto.apply = function (func, this, args)
 end
 
 func_proto.toString = function (this)
-  return 'function ' .. (this.name or '') .. '() { }'
+  local params = {}
+  local len = debug.getinfo(this, 'u').nparams - 1
+  for i=0,len-1 do
+    table.insert(params, tm.paramname(this, i))
+  end
+  return 'function ' .. (this.name or '') .. '(' .. table.concat(params, ', ') .. ') { [compiled code] }'
 end
 
 -- array prototype

--- a/test/issues/issue-runtime-628.js
+++ b/test/issues/issue-runtime-628.js
@@ -1,0 +1,14 @@
+var tap = require('../tap');
+
+tap.count(1);
+
+function getparams (fn) {
+	return fn.toString().match(/\(([^\)]+)/)[1].split(/,\s*/);
+}
+
+function ok (a, b, c) {
+	console.log('yay');
+}
+
+console.log('#', ok.toString())
+tap.eq(getparams(ok).join(','), 'a,b,c', 'can extract param names from fn');


### PR DESCRIPTION
Closes #628.
