### PR TITLE
Supports builtin NODE_VERSION from Makefile, Colony v from package.json.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ CONFIG ?= Release
 
 ifeq ($(ARM),1)
 	compile = \
-		AR=arm-none-eabi-ar AR_host=arm-none-eabi-ar AR_target=arm-none-eabi-ar CC=arm-none-eabi-gcc CXX=arm-none-eabi-g++ gyp $(1) --depth=. -f ninja-arm -D builtin_section=.rodata -D enable_ssl=$(ENABLE_TLS) -D enable_net=$(ENABLE_NET) &&\
+		AR=arm-none-eabi-ar AR_host=arm-none-eabi-ar AR_target=arm-none-eabi-ar CC=arm-none-eabi-gcc CXX=arm-none-eabi-g++ gyp $(1) --depth=. -f ninja-arm -D builtin_section=.rodata -D node_version=$(NODE_VERSION) -D enable_ssl=$(ENABLE_TLS) -D enable_net=$(ENABLE_NET) &&\
 		ninja -C out/$(CONFIG)
 else
     compile = \
-        gyp $(1) --depth=. -f ninja -D enable_ssl=$(ENABLE_TLS) -D enable_net=$(ENABLE_NET) -D enable_luajit=$(ENABLE_LUAJIT) -D compiler_path="$(shell pwd)/node_modules/colony-compiler/bin/colony-compiler.js" &&\
+        gyp $(1) --depth=. -f ninja -D enable_ssl=$(ENABLE_TLS) -D node_version=$(NODE_VERSION) -D enable_net=$(ENABLE_NET) -D enable_luajit=$(ENABLE_LUAJIT) -D compiler_path="$(shell pwd)/node_modules/colony-compiler/bin/colony-compiler.js" &&\
 		ninja -C out/$(CONFIG)
 endif
 

--- a/common.gypi
+++ b/common.gypi
@@ -18,6 +18,7 @@
     "approxidate_path": "./deps/approxidate",
     'enable_ssl%': 0,
     'enable_luajit%': 0,
+    'node_version%': "0.10.0",
     "compiler_path%": "",
   },
 

--- a/libcolony.gyp
+++ b/libcolony.gyp
@@ -200,7 +200,9 @@
       "type": "static_library",
       'cflags': [ '-Wall', '-Wextra', '-Werror' ],
       'defines': [
-        'COLONY_COMPILER_PATH=<(compiler_path)'
+        'COLONY_COMPILER_PATH=<(compiler_path)',
+        'COLONY_NODE_VERSION=<(node_version)',
+        '__TESSEL_RUNTIME_SEMVER__=<!(node -p \"require(\\\"./package.json\\\").version")',
       ],
       "sources": [
         'src/tm_event.c',

--- a/package.json
+++ b/package.json
@@ -22,9 +22,10 @@
   },
   "dependencies": {
     "async": "~0.2.9",
+    "bindings": "~1.2.0",
     "colony-compiler": "~0.6.23",
     "mkdirp": "~0.3.5",
-    "bindings": "~1.2.0"
+    "semver": "^4.1.0"
   },
   "devDependencies": {
     "nodejs-websocket": "^1.0.0",

--- a/src/colony/colony_runtime.c
+++ b/src/colony/colony_runtime.c
@@ -203,6 +203,10 @@ int colony_runtime_open ()
   lua_pushboolean(L, 0);
 #endif
   lua_setglobal(L, "COLONY_EMBED");
+  lua_pushstring(L, colony_runtime_xstr(COLONY_NODE_VERSION));
+  lua_setglobal(L, "COLONY_NODE_VERSION");
+  lua_pushstring(L, colony_runtime_xstr(__TESSEL_RUNTIME_SEMVER__));
+  lua_setglobal(L, "__TESSEL_RUNTIME_SEMVER__");
 
 #ifndef COLONY_EMBED
 #ifdef COLONY_COMPILER_PATH

--- a/src/colony/lua/preload.lua
+++ b/src/colony/lua/preload.lua
@@ -106,9 +106,10 @@ do
   global.process.platform = "tessel"
   global.process.arch = "armv7-m"
   global.process.versions = js_obj({
-    node = "v0.10.0",
-    colony = "v0.10.0"
+    node = 'v' .. COLONY_NODE_VERSION,
+    colony = 'v' .. __TESSEL_RUNTIME_SEMVER__
   })
+  global.process.version = global.process.versions.node
   global.process.EventEmitter = EventEmitter
   global.process.argv = js_arr({}, 0)
   global.process.env = js_obj({})
@@ -128,7 +129,6 @@ do
     return js_arr({[0]=math.floor(nanos / 1e9), nanos % 1e9}, 2)
   end
   global.process.nextTick = global.setImmediate
-  global.process.version = global.process.versions.node
 
   -- DEPLOY_TIME workaround for setting environmental time
 

--- a/test/colony/issue-runtime-627.js
+++ b/test/colony/issue-runtime-627.js
@@ -1,0 +1,10 @@
+var tap = require('../tap');
+
+tap.count(2);
+
+var semver = require('semver');
+
+// Checks internal versions have been set.
+console.log('#', JSON.stringify(process.versions, null, ''));
+tap.ok(semver.gte(process.versions.node, '0.10.30'), 'node version reports >= 0.10.30');
+tap.ok(semver.gte(process.versions.colony, '1.0.0'), 'colony version reports >= 1.0.0');


### PR DESCRIPTION
e.g. test output should now be

```
1..2
# {"node":"v0.10.32","colony":"v1.0.0"}
ok 1 - node version reports >= 0.10.30
ok 2 - colony version reports >= 1.0.0
```

See #627.
