### PR TITLE
Passing in buffer data to http parser

### DIFF
--- a/test/suite/http.js
+++ b/test/suite/http.js
@@ -2,6 +2,54 @@ var test = require('tinytap'),
     http = require('http'),
     net = require('net');
 
+
+var zlib = require('zlib');
+
+test('gunzip', function(t){
+  var hostname = 'tessel-httpbin.herokuapp.com';
+
+  var req = http.request({
+    hostname: hostname,
+    path: '/gzip',
+    method: 'GET'
+  }, function(res) {  
+    res.on('data', function (chunk) {   
+      zlib.gunzip(chunk, function(err, data){
+        t.ok(err == null, "sucessfully gunzipped");
+        
+        data = JSON.parse(data.toString());
+        t.equal(data.headers.Host, hostname);
+        t.end();
+      })
+    });
+
+  });
+
+  req.end();
+});
+
+test('inflate', function(t){
+  var http = require('http');
+  var hostname = 'tessel-httpbin.herokuapp.com';
+  var req = http.request({
+    hostname: hostname,
+    path: '/deflate',
+    method: 'GET'
+  }, function(res) {  
+    res.on('data', function (chunk) {   
+      zlib.inflate(chunk, function(err, data){
+        t.ok(err == null, "sucessfully deflated");
+        data = JSON.parse(data.toString());
+        t.equal(data.headers.Host, hostname);
+        t.end();
+      })
+    });
+
+  });
+
+  req.end();
+});
+
 test('client-basic', function (t) {
   // test based loosely on http://nodejs.org/api/http.html#http_http_request_options_callback
   var req = http.request({
@@ -376,50 +424,4 @@ test('keepalive', function (t) {
       });
     });
   }
-});
-
-var zlib = require('zlib');
-var hostname = 'tessel-httpbin.herokuapp.com';
-
-test('gunzip', function(t){
-  var req = http.request({
-    hostname: hostname,
-    path: '/gzip',
-    method: 'GET'
-  }, function(res) {  
-    res.on('data', function (chunk) {   
-      zlib.gunzip(chunk, function(err, data){
-        t.ok(err == null, "sucessfully gunzipped");
-        
-        data = JSON.parse(data.toString());
-        t.equal(data.headers.Host, hostname);
-        t.end();
-      })
-    });
-
-  });
-
-  req.end();
-});
-
-test('inflate', function(t){
-  var http = require('http');
-  var hostname = 'tessel-httpbin.herokuapp.com';
-  var req = http.request({
-    hostname: hostname,
-    path: '/deflate',
-    method: 'GET'
-  }, function(res) {  
-    res.on('data', function (chunk) {   
-      zlib.inflate(chunk, function(err, data){
-        t.ok(err == null, "sucessfully deflated");
-        data = JSON.parse(data.toString());
-        t.equal(data.headers.Host, hostname);
-        t.end();
-      })
-    });
-
-  });
-
-  req.end();
 });


### PR DESCRIPTION
Fixes Keen.io again. Or anything that sends binary data over http.

Test case is this:

``` js
var Keen = require('keen.io');

var keen = Keen.configure({
    projectId: "53fd0676e861701e17000001",
    writeKey: "510a87bcaca6d22103d47cb364520700218e44e2c99542331baf91e2988e143a1b891561838af27a9e4466b8834939c14547402f610a1e9075448740e97fc8b82918da10f409ffbab761eb6e394cccb7db133ba935d22a1189d1f91d70eed76b8f05b16133c91417da5438b15d4327f7",
    readKey: "e59871426c869471154eeebdf6e7feb02309f6d0d12574cd655fa8187d0dec5c16922b8a72364c3f192a5459e4debace4b70594fa8cd69e2af1f3b1c9d17d689677d20c806e7a690213122e8f022f496ee10c918013a07e246b3ae5247b66dc27167ee479f1d209c9f2aec115a5830a6"
});

var count = 0;
setImmediate(function sendToCloud(){
    keen.addEvent("tessel-climate", {
       "temp": 12345
     }, function (err, res){
        if (err){
            console.log("err occured", err);
        }
        console.log("res", res);
        count++;
        console.log("added event", count);
        setTimeout(sendToCloud, 1);
     });
});
```
