### PR TITLE
added date.toUTCString

### DIFF
--- a/src/colony/lua/colony-js.lua
+++ b/src/colony/lua/colony-js.lua
@@ -1606,7 +1606,10 @@ date_proto.toLocaleDateString = function () return ''; end
 date_proto.toLocaleString = function () return ''; end
 date_proto.toLocaleTimeString = function () return ''; end
 date_proto.toTimeString = function () return ''; end
-date_proto.toUTCString = function () return ''; end
+
+date_proto.toUTCString = function ()
+  return os.date('!%a, %d %h %Y %H:%M:%S GMT', getmetatable(this).date/1e6)
+end
 
 global.Date.now = function ()
   return math.floor(tonumber(tm.timestamp()/1e3)) or 0


### PR DESCRIPTION
This PR adds support for date.toUTCString(). 

I found out the hard way that a lot of date functions are not fully supported.

I'm a bit confused by timezones if and how they are implemented in lua/colony. It doesn't appear to be present. Maybe a more explicit end user command for initializing a tessel to a TZ would allow for these additional date functions to be flushed out. Again, my understanding currently is limited, but dates seem really important to me.

This patch gets me up and running with the npm/knox library for working with amazon s3.
