### PR TITLE
Pipe colony-compiler output instead of writing a temp file

### DIFF
--- a/src/colony/lua/preload.lua
+++ b/src/colony/lua/preload.lua
@@ -77,18 +77,15 @@ if not _G.COLONY_EMBED then
   -- This is temporary until we have proper compilation in C.
   colony._load = function (file)
     -- Compile JS script before running.
-    local status
+    assert(#_G.COLONY_COMPILER_PATH ~= 0, "COLONY_COMPILER_PATH is not defined")
+    local handle
     if jit == nil then
-      status = os.execute(_G.COLONY_COMPILER_PATH .. ' -m ' .. file .. ' > /tmp/colonyunique')
+      handle = io.popen(_G.COLONY_COMPILER_PATH .. ' -m "' .. file .. '"')
     else
-      status = os.execute(_G.COLONY_COMPILER_PATH .. ' -l ' .. file .. ' > /tmp/colonyunique')
+      handle = io.popen(_G.COLONY_COMPILER_PATH .. ' -l "' .. file .. '"')
     end
-    if status ~= 0 then
-      os.exit(status)
-    end
-    local file = io.open('/tmp/colonyunique', 'r')
-    local output = file:read('*all')
-    file:close()
+    local output = handle:read('*all')
+    handle:close()
     return output
   end
 end


### PR DESCRIPTION
- Doesn't leave a file in /tmp
- Avoids a symlink race vulnerability
- May not break on Windows
- Checks that the colony-compiler path is nonempty, because
  os.exit didn't return the passed error code before (#663)
