### PR TITLE
Fix http OutgoingMessage leaks, improve connection reuse a bit

### DIFF
--- a/src/colony/modules/http.js
+++ b/src/colony/modules/http.js
@@ -276,6 +276,7 @@ function OutgoingMessage () {
       if (self._chunked) {
         self._outbox.write('0\r\n'+self._trailer+'\r\n');
       }
+      self._outbox.end();
     }
   });
 }
@@ -288,7 +289,11 @@ OutgoingMessage.prototype._assignSocket = function (socket) {
   //       ClientRequest re-emits a public event asyncronously.
   this.emit('_socket-SYNC', socket);
   this._socket = socket;
-  this._outbox.pipe(socket, {end:false});
+  var self = this;
+  self._outbox.pipe(socket, {end:false});
+  self._outbox.on('end', function () {
+      self._outbox.unpipe(socket);
+  });
   // TODO: setTimeout/setNoDelay/setSocketKeepAlive
 };
 

--- a/src/colony/modules/http.js
+++ b/src/colony/modules/http.js
@@ -451,9 +451,9 @@ function _getPool(agent, opts) {
         freeSockets.push(socket);
       } else {
         socket.end();
+        socket.destroy();     // TODO: why is this even necessary??!
       }
       removeSocket(socket);
-      socket.destroy();
     }
   }
   

--- a/src/colony/modules/http.js
+++ b/src/colony/modules/http.js
@@ -288,7 +288,7 @@ OutgoingMessage.prototype._assignSocket = function (socket) {
   //       ClientRequest re-emits a public event asyncronously.
   this.emit('_socket-SYNC', socket);
   this._socket = socket;
-  this._outbox.pipe(socket);
+  this._outbox.pipe(socket, {end:false});
   // TODO: setTimeout/setNoDelay/setSocketKeepAlive
 };
 


### PR DESCRIPTION
This fixes the leaks on https://github.com/tessel/runtime/issues/655 and also fixes up some halfway-related issues noticed in other posthumous 'http' review.

(Note: there's still one outstanding "leak" warning that I see when running http tests under posix, but not with the superficially associated test's isolate code itself. So I suspect this might actually be related to the global 'tcp-close' but even if not can be dealt with separately should it cause real-world problems.)
