### PR TITLE
Set default Agent's initial maxSockets to 1

### DIFF
--- a/src/colony/modules/http.js
+++ b/src/colony/modules/http.js
@@ -372,7 +372,7 @@ function Agent (opts) {
   opts = util._extend({
     keepAlive: false,
     keepAliveMsecs: 1000,
-    maxSockets: 2,      // NOTE: node has `Infinity`
+    maxSockets: Infinity,
     maxFreeSockets: 1   // NOTE: node has `256`
   }, opts);
   

--- a/src/colony/modules/http.js
+++ b/src/colony/modules/http.js
@@ -372,7 +372,7 @@ function Agent (opts) {
   opts = util._extend({
     keepAlive: false,
     keepAliveMsecs: 1000,
-    maxSockets: Infinity,
+    maxSockets: 1,
     maxFreeSockets: 1   // NOTE: node has `256`
   }, opts);
   


### PR DESCRIPTION
The [new rationale](https://github.com/tessel/runtime/issues/674#issuecomment-66214631) here is that:
- the lower, the better as far as current CC3K stack goes
- this may also make it a little clearer where the problem lies in situations like #674, than the previous value of 2

@LinusU how does this sound as a replacement for #675?
