### PR TITLE
Convert stdout/stderr chunks to string (if not already) before logging

### DIFF
--- a/src/colony/lua/preload.lua
+++ b/src/colony/lua/preload.lua
@@ -174,12 +174,12 @@ do
 
   colony.global.process.stdout = colony.js_new(Writable)
   colony.global.process.stdout._write = function (this, chunk, encoding, callback)
-    tm.log(10, chunk:toString())
+    tm.log(10, chunk)
     callback()
   end
   colony.global.process.stderr = colony.js_new(Writable)
   colony.global.process.stderr._write = function (this, chunk, encoding, callback)
-    tm.log(13, chunk:toString())
+    tm.log(13, chunk)
     callback()
   end
 

--- a/src/colony/lua/preload.lua
+++ b/src/colony/lua/preload.lua
@@ -174,12 +174,12 @@ do
 
   colony.global.process.stdout = colony.js_new(Writable)
   colony.global.process.stdout._write = function (this, chunk, encoding, callback)
-    tm.log(10, chunk)
+    tm.log(10, chunk:toString())
     callback()
   end
   colony.global.process.stderr = colony.js_new(Writable)
   colony.global.process.stderr._write = function (this, chunk, encoding, callback)
-    tm.log(13, chunk)
+    tm.log(13, chunk:toString())
     callback()
   end
 

--- a/src/colony/lua_tm.c
+++ b/src/colony/lua_tm.c
@@ -120,7 +120,7 @@ static int l_tm_log(lua_State* L)
 {
   const char level = lua_tonumber(L, 1);
   size_t buf_len = 0;
-  const char* buf = (const char*) colony_tolutf8(L, 2, &buf_len);
+  const char* buf = (const char*) colony_toconstdata(L, 2, &buf_len);
   tm_log(level, buf, buf_len);
   return 0;
 }

--- a/test/issues/issue-runtime-686.js
+++ b/test/issues/issue-runtime-686.js
@@ -1,0 +1,2 @@
+console.log('1..1');
+process.stdout.write(Buffer("ok 1 - buffer written to stdout\n"));


### PR DESCRIPTION
It is not proper to pass a buffer directly into tm_log, this fixes a segfault when piping (or simply writing buffers) to `process.stdout`.
