### PR TITLE
Do not add newlines to direct process.stdout/stderr writes

### DIFF
--- a/src/colony/lua/preload.lua
+++ b/src/colony/lua/preload.lua
@@ -174,12 +174,12 @@ do
 
   colony.global.process.stdout = colony.js_new(Writable)
   colony.global.process.stdout._write = function (this, chunk, encoding, callback)
-    tm.log(10, chunk)
+    tm.log(30, chunk)
     callback()
   end
   colony.global.process.stderr = colony.js_new(Writable)
   colony.global.process.stderr._write = function (this, chunk, encoding, callback)
-    tm.log(13, chunk)
+    tm.log(31, chunk)
     callback()
   end
 

--- a/src/tm_log.c
+++ b/src/tm_log.c
@@ -15,7 +15,13 @@
 #include <unistd.h>
 void tm_log(char level, const char* string, unsigned length) {
 	char linebreak = '\n';
-	if (level != 13) {
+	if (level == 30) {
+		// raw stdout
+		(void) fwrite(string, 1, length, stdout);
+	} else if (level == 31) {
+		// raw stderr
+		(void) fwrite(string, 1, length, stderr);
+	} else if (level != 13) {
 		int r = fwrite(string, 1, length, stdout);
 		r = fwrite(&linebreak, 1, 1, stdout);
 		(void) r;


### PR DESCRIPTION
Fixes #319 for "PC" use cases. Depends on https://github.com/tessel/cli/pull/166 — otherwise as it sits now, the CLI will silently drop the new "raw" messages by default.
