### PR TITLE
Converts url of incoming request into a utf-8 encoded string

### DIFF
--- a/src/colony/modules/http.js
+++ b/src/colony/modules/http.js
@@ -124,7 +124,7 @@ function IncomingMessage (type, socket) {
       self.emit('_messageBegin');
     }),
     onUrl: parserCallback(function (url) {
-      self.url = url;
+      self.url = url.toString('utf8');
     }),
     onHeaderField: parserCallback(function (field) {
       field = field.toString();


### PR DESCRIPTION
An IncomingMessage request URL should be a string, not a buffer, as evidenced by [the Node docs](http://nodejs.org/api/http.html#http_message_url). 
