### PR TITLE
Escape arguments in luajit-build.sh

### DIFF
--- a/tools/luajit-build.sh
+++ b/tools/luajit-build.sh
@@ -3,7 +3,7 @@
 set -e
 
 MYPATH=`dirname $0`
-TARGET=$(pwd)/$2
+TARGET="$(pwd)/$2"
 # gcc on Linux, clang on OS X, doesn't matter
 LJ_CC=gcc
 
@@ -14,4 +14,4 @@ else
 	make HOST_CFLAGS="-DLUAJIT_COLONY -g" TARGET_CFLAGS="-DLUAJIT_COLONY -g" || true
 fi
 cd ../..
-cp deps/colony-luajit/src/libluajit.a $TARGET
+cp deps/colony-luajit/src/libluajit.a "$TARGET"


### PR DESCRIPTION
If you try to build the firmware (which includes this project as a submodule), and the directory you are building from has a space somewhere in the path (e.g /home/user/Google Drive/Development/Tessel/firmware) then the build fails. This patch escapes the parameter with quotation marks help make the luajit-build.sh more robust.