### PR TITLE
Allow tests to pass in the summer.

### DIFF
--- a/test/issues/issue-runtime-669.js
+++ b/test/issues/issue-runtime-669.js
@@ -1,6 +1,6 @@
 var tap = require('../tap');
 
-tap.count(40);
+tap.count(38);
 
 var d = new Date();
 var offset = d.getTimezoneOffset() * 60000;
@@ -28,11 +28,6 @@ d.setHours(8);
 tap.eq(40, d.getMinutes());
 tap.eq(20, d.getSeconds());
 tap.eq(8, d.getHours());
-
-d = new Date();
-d.setTime(35 + offset);
-tap.eq(1970, d.getFullYear());
-tap.eq(35, d.getMilliseconds());
 
 /** DATE **/
 

--- a/test/issues/issue-runtime-669.js
+++ b/test/issues/issue-runtime-669.js
@@ -1,6 +1,6 @@
 var tap = require('../tap');
 
-tap.count(38);
+tap.count(36);
 
 var d = new Date();
 var offset = d.getTimezoneOffset() * 60000;
@@ -100,16 +100,6 @@ tap.eq(d.toLocaleTimeString(), '16:00:00');
 testEqIgnoreTimezoneName(d.toLocaleString(), 'Wed Dec 02 1992 16:00:00 GMT+0000 (GMT)');
 
 /** UTC **/
-
-d = new Date();
-d.setHours(16);
-d.setMinutes(0);
-tap.eq(d.getUTCHours(), Math.floor(16 + offsetHours) % 24);
-
-d = new Date();
-d.setUTCHours(16);
-d.setUTCMinutes(0);
-tap.eq(d.getHours(), Math.floor(16 - offsetHours) % 24);
 
 d = new Date();
 d.setMinutes(35);


### PR DESCRIPTION
Remove a broken test that depends on the current DST status matching
the DST status of Jan 1.
