### PR TITLE
Warn about different local Node.js versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This is the runtime and JavaScript engine that runs on Tessel, built on Lua's VM
 
 Building the firmware requires [gyp](https://code.google.com/p/gyp/), and [ninja](http://martine.github.io/ninja/), and [gcc-arm-embedded](https://launchpad.net/gcc-arm-embedded) when building for embedded.
 
+**Important note:**
+*Because Colony uses your installed node version to generate deployment code, you have to know there could be different behaviours from different versions of Node.js (more: see make test on Ubuntu 14.04)*
+
 #### OS X
 
 To install quickly on a Mac with [Brew](http://brew.sh):
@@ -19,8 +22,12 @@ brew install gcc-arm # to build for embedded
 All dependencies are in the Ubuntu 14.04 repositories:
 
 ```
-sudo apt-get install git nodejs npm nodejs-legacy gyp ninja-build
-sudo apt-get install gcc-arm-none-eabi # to build for embedded
+sudo apt-get install build-essential libssl-dev
+curl https://raw.githubusercontent.com/creationix/nvm/v0.16.1/install.sh | sh
+nvm ls-remote
+nvm install 0.12.3
+nvm use 0.12.3
+sudo apt-get install git nodejs-legacy gyp ninja-build gcc-arm-none-eabi # to build for embedded
 ```
 
 ## Building (PC or Embedded)
@@ -30,8 +37,16 @@ git clone https://github.com/tessel/runtime.git
 cd runtime
 make update
 make colony
+```
+
+**Important note:**
+Because Colony development started when Node.js version 0.10.13 was released, we run into challenge to stay compatible with following Node.js versions. 
+The strategie we follow to transcompile to Lua-Bytecode forced us to implement new Node.js features or fixes manually.
+Our test cases for Colony are done streight forward but you will see **different** [numbers of failing tests](https://github.com/tessel/t1-runtime/issues/727) what cause at low level code.
+```
 make test
 ```
+Please notice the open issues to find known problems.
 
 To link globally, run `npm link --local`. You can now run code on your PC using `colony` from your command line (e.g. `colony hello-world.js`). For building firmware, please see the [firmware building instructions](https://github.com/tessel/firmware).
 


### PR DESCRIPTION
It is necessary to warn nice people before contributing about the
behavior and failing tests related to different versions of local
installed Node.js